### PR TITLE
Enable public_member_api_docs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,4 +5,8 @@ analyzer:
     - "**/*.freezed.dart"
     - "**/*.g.dart"
     - "**/*.mocks.dart"
-    - "**/l10n/*.dart"
+    - "**/*_localizations*.dart"
+
+linter:
+  rules:
+    public_member_api_docs: true


### PR DESCRIPTION
As opposed to canonical/ubuntu-desktop-installer#467, these general
purpose library packages should have public API documented.