### PR TITLE
logger: add missing docs

### DIFF
--- a/packages/ubuntu_logger/README.md
+++ b/packages/ubuntu_logger/README.md
@@ -1,0 +1,42 @@
+# Ubuntu Logger for Dart
+
+A logging frontend based on Google's [logging](https://pub.dev/packages/logging)
+library for Dart.
+
+## Usage
+
+Import the library:
+
+```dart
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+```
+
+Setup logging:
+
+```dart
+void main() {
+  Logger.setup(
+    path: '/path/to/file.log',
+    level: LogLevel.info,
+  );
+}
+```
+
+Log messages:
+
+```dart
+final log = Logger('a_context');
+
+log.debug('This is a debug message.');
+log.info('This is an info message.');
+```
+
+Prints to the console:
+```
+INFO a_context: This is an info message.
+```
+
+Writes to the log file:
+```
+YYYY-MM-DD HH:MM:SS.zzzzzz INFO a_context: This is an info message.
+```

--- a/packages/ubuntu_logger/lib/src/ubuntu_logger.dart
+++ b/packages/ubuntu_logger/lib/src/ubuntu_logger.dart
@@ -8,6 +8,8 @@ import 'package:path/path.dart' as p;
 // ignore: avoid_classes_with_only_static_members
 /// Defines available logging levels.
 abstract class LogLevel {
+  const LogLevel._();
+
   /// All messages, including debug output.
   static const debug = log.Level('DEBUG', 0);
 

--- a/packages/ubuntu_logger/lib/ubuntu_logger.dart
+++ b/packages/ubuntu_logger/lib/ubuntu_logger.dart
@@ -1,3 +1,21 @@
+/// A logging frontend based on Google's [logging](https://pub.dev/packages/logging)
+/// library for Dart.
+///
+/// ```dart
+/// import 'package:ubuntu_logger/ubuntu_logger.dart';
+///
+/// final log = Logger('a_context');
+///
+/// void main() {
+///   Logger.setup(
+///     path: '/path/to/file.log',
+///     level: LogLevel.info,
+///   );
+///
+///   log.debug('This is a debug message.');
+///   log.info('This is an info message.');
+/// }
+/// ```
 library ubuntu_logger;
 
 export 'src/ubuntu_logger.dart';


### PR DESCRIPTION
Add missing README, library-level docs, and make LogLevel constructor
internal to avoid that it shows up in the docs.