### PR TITLE
Enable `sort_pub_dependencies` linter rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,3 +10,4 @@ analyzer:
 linter:
   rules:
     public_member_api_docs: true
+    sort_pub_dependencies: true


### PR DESCRIPTION
Enable `sort_pub_dependencies` to ensure that dependencies stay sorted.
Sorting dependencies makes maintenance easier, and it also plays better
together with Pubspec Assist.