### PR TITLE
Added test to verify user scrolling experience remains unaffected after lines are added to the LogView widget.

### DIFF
--- a/packages/ubuntu_widgets/test/log_view_test.dart
+++ b/packages/ubuntu_widgets/test/log_view_test.dart
@@ -42,4 +42,52 @@ void main() {
     expect(scrollController.position.extentAfter, equals(0.0));
     expect(scrollController.position.maxScrollExtent, greaterThan(0.0));
   });
+
+  testWidgets('user scroll not affected by appended lines', (tester) async {
+    final log = StreamController<String>(sync: true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LogView(log: log.stream, maxLines: 2),
+        ),
+      ),
+    );
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+
+    final controller = textField.controller;
+    expect(controller, isNotNull);
+
+    final scrollController = textField.scrollController;
+    expect(scrollController, isNotNull);
+
+    for (int i = 1; i < 6; i++) {
+      log.add('line $i');
+      await tester.pump();
+    }
+    expect(controller!.text, equals('line 1\nline 2\nline 3\nline 4\nline 5'));
+    expect(scrollController!.offset, greaterThan(0.0));
+    expect(scrollController.position.extentAfter, equals(0.0));
+    expect(scrollController.position.maxScrollExtent, greaterThan(0.0));
+
+    // moving scroll manually
+    scrollController.jumpTo(0.0);
+    await tester.pump();
+    _scrollOffsetShouldStayAt0(scrollController);
+
+    log.add('line 6');
+    await tester.pump();
+    expect(
+      controller.text,
+      equals('line 1\nline 2\nline 3\nline 4\nline 5\nline 6'),
+    );
+    _scrollOffsetShouldStayAt0(scrollController);
+  });
+}
+
+void _scrollOffsetShouldStayAt0(ScrollController scrollController) {
+  expect(scrollController.offset, equals(0.0));
+  expect(scrollController.position.extentAfter, greaterThan(0.0));
+  expect(scrollController.position.maxScrollExtent, greaterThan(0.0));
 }


### PR DESCRIPTION
Based on @didrocks questions in [this discussion](https://github.com/ubuntu/ubuntu-wsl-splash/pull/2#discussion_r782794192) I had to experiment and make tests to ensure the user scrolling experience with the LogView widget is not disturbed when I new line is added.

If I understood his concern correctly, the expected behavior is represented in the gif below:
![log_view_scroll](https://user-images.githubusercontent.com/11138291/149967230-cd89e7ae-6e66-40f6-b3ba-0ec4903442fa.gif)


It turns out that out of the box the widget already presents the desired behavior, so I just added a test to demonstrate that.

