### PR TITLE
LogView: don't attempt to scroll when unmounted

### DIFF
--- a/packages/ubuntu_widgets/lib/src/log_view.dart
+++ b/packages/ubuntu_widgets/lib/src/log_view.dart
@@ -77,8 +77,8 @@ class _LogViewState extends State<LogView> {
 
   bool _isAtEnd() => _scrollController.position.extentAfter == 0;
   void _scrollToEnd() {
-    if (!mounted) return;
     WidgetsBinding.instance!.addPostFrameCallback((_) {
+      if (!mounted) return;
       _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
     });
   }


### PR DESCRIPTION
See https://github.com/ubuntu/ubuntu-wsl-splash/pull/2/files#r782812281
> `_scrollToEnd()` schedules an asynchronous post frame callback, _but_ the `mounted` check should be inside the callback, not before scheduling the call, because the widget is not guaranteed to be mounted at that point when the callback gets called... (my bad :))
