### PR TITLE
handy_window_example: fix analysis failure

### DIFF
--- a/packages/handy_window/example/lib/main.dart
+++ b/packages/handy_window/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 import 'package:yaru/yaru.dart';
 
 void main() {
@@ -59,7 +59,7 @@ class ClickableLink extends StatelessWidget {
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
-        onTap: () => launch(url),
+        onTap: () => launchUrlString(url),
         child: DefaultTextStyle(
           style: TextStyle(
             color: Colors.blue.shade700,

--- a/packages/handy_window/example/pubspec.yaml
+++ b/packages/handy_window/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   handy_window:
     path: ../
-  url_launcher: ^6.0.20
+  url_launcher: ^6.1.0
   yaru: ^0.2.2
 
 dev_dependencies:


### PR DESCRIPTION
Unblocks the CI:
```
handy_window_example:
Analyzing example...                                            

   info • 'launch' is deprecated and shouldn't be used. Use launchUrl instead • lib/main.dart:62:22 • deprecated_member_use

1 issue found. (ran in 0.8s)
```
Same as https://github.com/canonical/ubuntu-desktop-installer/pull/804 for the installer.