### PR TITLE
Introduce ScopedFocusTraversalGroup & friends

### DIFF
--- a/packages/ubuntu_widgets/lib/src/scoped_focus_traversal.dart
+++ b/packages/ubuntu_widgets/lib/src/scoped_focus_traversal.dart
@@ -93,11 +93,6 @@ class ScopedFocusTraversalPolicy extends FocusTraversalPolicy {
   }
 
   @override
-  FocusNode findLastFocus(FocusNode currentNode) {
-    return findFirstFocus(currentNode) ?? currentNode;
-  }
-
-  @override
   FocusNode? findFirstFocusInDirection(
       FocusNode currentNode, TraversalDirection direction) {
     return findFirstFocus(currentNode);

--- a/packages/ubuntu_widgets/lib/src/scoped_focus_traversal.dart
+++ b/packages/ubuntu_widgets/lib/src/scoped_focus_traversal.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+
+/// A scoped focus traversal group.
+///
+/// Commonly used to build desktop-style focus traversal scopes so that Tab
+/// focus traverses first the "selected" list item, and vertical key navigation
+/// is contained within the list view.
+///
+/// ```dart
+/// ScopedFocusTraversalGroup(
+///   child: ListView.builder(
+///     itemCount: 10,
+///     itemBuilder: (context, index) {
+///       return ScopedFocusTraversalOrder(
+///         focus: index == _selectedIndex,
+///         child: ListTile(
+///           selected: index == _selectedIndex,
+///           // ...
+///         ),
+///       );
+///     },
+///   ),
+/// )
+/// ```
+///
+/// See also:
+///
+///  * [ScopedFocusTraversalOrder]
+///  * [ScopedFocusTraversalPolicy]
+class ScopedFocusTraversalGroup extends FocusTraversalGroup {
+  /// Constructs a scoped focus traversal group.
+  ScopedFocusTraversalGroup({
+    super.key,
+    required super.child,
+    FocusTraversalPolicy? secondary,
+  }) : super(policy: ScopedFocusTraversalPolicy(secondary: secondary));
+}
+
+/// A scoped focus traversal order.
+///
+/// See also:
+///
+///  * [ScopedFocusTraversalGroup]
+///  * [ScopedFocusTraversalPolicy]
+class ScopedFocusTraversalOrder extends StatelessWidget {
+  /// Constructs a scoped focus traversal order.
+  const ScopedFocusTraversalOrder({
+    super.key,
+    required this.child,
+    this.focus = false,
+  });
+
+  /// Whether the child requests focus.
+  final bool focus;
+
+  /// The child of this widget.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!focus) return child;
+    return FocusTraversalOrder(
+      order: const NumericFocusOrder(0),
+      child: child,
+    );
+  }
+}
+
+/// A scoped focus traversal policy.
+///
+/// See also:
+///
+///  * [ScopedFocusTraversalGroup]
+///  * [ScopedFocusTraversalOrder]
+class ScopedFocusTraversalPolicy extends FocusTraversalPolicy {
+  /// Constructs a scoped focus traversal policy.
+  ScopedFocusTraversalPolicy({FocusTraversalPolicy? secondary})
+      : secondary = secondary ?? OrderedTraversalPolicy(secondary: secondary);
+
+  /// The policy to use as a secondary focus traversal order.
+  final FocusTraversalPolicy secondary;
+
+  @override
+  Iterable<FocusNode> sortDescendants(
+    Iterable<FocusNode> descendants,
+    FocusNode currentNode,
+  ) {
+    if (descendants.contains(primaryFocus)) {
+      return [primaryFocus!];
+    }
+    final sorted = secondary.sortDescendants(descendants, currentNode);
+    return sorted.isNotEmpty ? [sorted.first] : [];
+  }
+
+  @override
+  FocusNode findLastFocus(FocusNode currentNode) {
+    return findFirstFocus(currentNode) ?? currentNode;
+  }
+
+  @override
+  FocusNode? findFirstFocusInDirection(
+      FocusNode currentNode, TraversalDirection direction) {
+    return findFirstFocus(currentNode);
+  }
+
+  @override
+  bool inDirection(FocusNode currentNode, TraversalDirection direction) {
+    final focusedChild = currentNode.nearestScope?.focusedChild;
+    final children = currentNode.parent?.traversalChildren ?? [];
+    // assumes that the scope is a vertical list. expose an axes property if
+    // more control is needed.
+    if ((direction == TraversalDirection.up &&
+            focusedChild == children.first) ||
+        (direction == TraversalDirection.down &&
+            focusedChild == children.last)) {
+      return false;
+    }
+    return secondary.inDirection(currentNode, direction);
+  }
+}

--- a/packages/ubuntu_widgets/lib/ubuntu_widgets.dart
+++ b/packages/ubuntu_widgets/lib/ubuntu_widgets.dart
@@ -9,6 +9,7 @@ export 'src/menu_button_builder.dart';
 export 'src/radio_button.dart';
 export 'src/rounded_container.dart';
 export 'src/rounded_list_view.dart';
+export 'src/scoped_focus_traversal.dart';
 export 'src/slide_show.dart';
 export 'src/toggle_button.dart';
 export 'src/toggle_button_theme.dart';

--- a/packages/ubuntu_widgets/test/scoped_focus_traversal_test.dart
+++ b/packages/ubuntu_widgets/test/scoped_focus_traversal_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+
+void main() {
+  testWidgets('tab focus', (tester) async {
+    final button1Node = FocusNode();
+    final button2Node = FocusNode();
+    final itemNodes = [for (var i = 0; i < 10; ++i) FocusNode()];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: [
+            ElevatedButton(
+              focusNode: button1Node,
+              onPressed: () {},
+              child: const SizedBox.shrink(),
+            ),
+            Expanded(
+              child: ScopedFocusTraversalGroup(
+                child: ListView.builder(
+                  itemCount: 10,
+                  itemBuilder: (context, index) {
+                    return ScopedFocusTraversalOrder(
+                      focus: index == 5,
+                      child: ListTile(
+                        focusNode: itemNodes[index],
+                        onTap: () {},
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            ElevatedButton(
+              focusNode: button2Node,
+              onPressed: () {},
+              child: const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    expect(button1Node.hasFocus, isFalse);
+    expect(itemNodes.every((node) => node.hasFocus), isFalse);
+    expect(button2Node.hasFocus, isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    expect(button1Node.hasFocus, isTrue);
+    expect(itemNodes.every((node) => node.hasFocus), isFalse);
+    expect(button2Node.hasFocus, isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    expect(button1Node.hasFocus, isFalse);
+    expect(itemNodes[5].hasFocus, isTrue);
+    expect(button2Node.hasFocus, isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    expect(button1Node.hasFocus, isFalse);
+    expect(itemNodes.every((node) => node.hasFocus), isFalse);
+    expect(button2Node.hasFocus, isTrue);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    addTearDown(() => tester.sendKeyUpEvent(LogicalKeyboardKey.shift));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    expect(button1Node.hasFocus, isFalse);
+    expect(itemNodes[5].hasFocus, isTrue);
+    expect(button2Node.hasFocus, isFalse);
+  });
+
+  testWidgets('key navigation', (tester) async {
+    final button1Node = FocusNode();
+    final button2Node = FocusNode();
+    final itemNodes = [for (var i = 0; i < 10; ++i) FocusNode()];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: [
+            ElevatedButton(
+              focusNode: button1Node,
+              onPressed: () {},
+              child: const SizedBox.shrink(),
+            ),
+            Expanded(
+              child: ScopedFocusTraversalGroup(
+                child: ListView.builder(
+                  itemCount: 10,
+                  itemBuilder: (context, index) {
+                    return ScopedFocusTraversalOrder(
+                      focus: index == 3,
+                      child: ListTile(
+                        autofocus: index == 3,
+                        focusNode: itemNodes[index],
+                        onTap: () {},
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            ElevatedButton(
+              focusNode: button2Node,
+              onPressed: () {},
+              child: const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    expect(itemNodes[3].hasFocus, isTrue);
+
+    for (var i = 2; i >= 0; --i) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      expect(itemNodes[i + 1].hasFocus, isFalse);
+      expect(itemNodes[i].hasFocus, isTrue);
+    }
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    expect(itemNodes[0].hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    expect(itemNodes[0].hasFocus, isFalse);
+    expect(itemNodes[1].hasFocus, isTrue);
+
+    for (var i = 2; i < 10; ++i) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(itemNodes[i - 1].hasFocus, isFalse);
+      expect(itemNodes[i].hasFocus, isTrue);
+    }
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    expect(itemNodes[9].hasFocus, isTrue);
+  });
+}

--- a/packages/ubuntu_widgets/test/scoped_focus_traversal_test.dart
+++ b/packages/ubuntu_widgets/test/scoped_focus_traversal_test.dart
@@ -137,4 +137,60 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     expect(itemNodes[9].hasFocus, isTrue);
   });
+
+  testWidgets('first focus up', (tester) async {
+    final itemNodes = [for (var i = 0; i < 10; ++i) FocusNode()];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ScopedFocusTraversalGroup(
+          child: ListView.builder(
+            itemCount: 10,
+            itemBuilder: (context, index) {
+              return ScopedFocusTraversalOrder(
+                focus: index == 5,
+                child: ListTile(
+                  focusNode: itemNodes[index],
+                  onTap: () {},
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(itemNodes.every((node) => node.hasFocus), isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    expect(itemNodes.last.hasFocus, isTrue);
+  });
+
+  testWidgets('first focus down', (tester) async {
+    final itemNodes = [for (var i = 0; i < 10; ++i) FocusNode()];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ScopedFocusTraversalGroup(
+          child: ListView.builder(
+            itemCount: 10,
+            itemBuilder: (context, index) {
+              return ScopedFocusTraversalOrder(
+                focus: index == 5,
+                child: ListTile(
+                  focusNode: itemNodes[index],
+                  onTap: () {},
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(itemNodes.every((node) => node.hasFocus), isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    expect(itemNodes.first.hasFocus, isTrue);
+  });
 }


### PR DESCRIPTION
A scoped focus traversal group provides a desktop-like focus traversal
order and policy for list views and alike so that Tab focus traverses
first the "selected" list item, and vertical key navigation is contained
within the list view.

Ref: canonical/ubuntu-desktop-installer#343