### PR TITLE
TimezoneMap: fix fractional timezone offset formatting

### DIFF
--- a/packages/timezone_map/lib/src/map.dart
+++ b/packages/timezone_map/lib/src/map.dart
@@ -92,7 +92,7 @@ class TimezoneMap extends StatelessWidget {
 
 // Shortest double (%g) representation: 0, 1, 5.5, 5.75, ...
 String _formatTimezoneOffset(double offset) {
-  final format = NumberFormat();
+  final format = NumberFormat(null, 'en_US'); // decimal separator = "."
   format.minimumFractionDigits = 0;
   format.maximumFractionDigits = 2;
   return format.format(offset);

--- a/packages/timezone_map/test/map_test.dart
+++ b/packages/timezone_map/test/map_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:mockito/mockito.dart';
 import 'package:timezone_map/timezone_map.dart';
@@ -103,6 +104,14 @@ void main() {
 
     await tester.pumpWidget(buildMap(tester, offset: 1.23));
     expect(tester.takeException(), isFlutterError);
+  });
+
+  testWidgets('locale', (tester) async {
+    Intl.defaultLocale = 'sv_SE'; // decimal separator = ","
+    addTearDown(() => Intl.defaultLocale = null);
+
+    await tester.pumpWidget(buildMap(tester, offset: 5.75));
+    expect(find.svg('tz_5.75.svg'), findsOneWidget);
   });
 
   testWidgets('map size', (tester) async {


### PR DESCRIPTION
When formatting fractional timezone offsets, force the "en_US" locale
to ensure that "." is used as the decimal separator instead of "," that
some (e.g. nordic) locales use.

This fixes the issue that depending on the value of `Intl.defaultLocale`,
the map would try to load SVGs with wrong file names such as "tz_5,5.svg"
instead of "tz_5.5.svg" for India.