### PR TITLE
SlideShow: expose the slide animation curve and duration

### DIFF
--- a/packages/ubuntu_widgets/lib/src/slide_show.dart
+++ b/packages/ubuntu_widgets/lib/src/slide_show.dart
@@ -9,9 +9,14 @@ const _kButtonSize = 80.0;
 const _kIconColor = Colors.black87;
 const _kIconSize = 48.0;
 
-const _kSlideCurve = Curves.easeInOut;
-const _kSlideDuration = Duration(milliseconds: 250);
-const _kSlideInterval = Duration(seconds: 15);
+/// The default curve for slide transitions.
+const kSlideCurve = Curves.easeInOut;
+
+/// The default duration for slide transitions.
+const kSlideDuration = Duration(milliseconds: 250);
+
+/// The default interval for automatic slide changes.
+const kSlideInterval = Duration(seconds: 15);
 
 /// Displays a set of slides, or any widgets, that animate in and out at a
 /// specified interval. The slides can be manually navigated by pressing arrow
@@ -21,7 +26,9 @@ class SlideShow extends StatefulWidget {
   SlideShow({
     super.key,
     required this.slides,
-    this.interval = _kSlideInterval,
+    this.curve = kSlideCurve,
+    this.duration = kSlideDuration,
+    this.interval = kSlideInterval,
     this.wrap = false,
     this.autofocus = false,
     this.focusNode,
@@ -31,7 +38,13 @@ class SlideShow extends StatefulWidget {
   /// The list of slides to show.
   final List<Widget> slides;
 
-  /// The interval for automatic slide changes. The default is 15 seconds.
+  /// The curve for slide transitions. Defaults to [kSlideCurve].
+  final Curve curve;
+
+  /// The duration for slide transitions. Defaults to [kSlideDuration].
+  final Duration duration;
+
+  /// The interval for automatic slide changes. Defaults to [kSlideInterval].
   final Duration interval;
 
   /// Whether to wrap around. The default value is false.
@@ -87,8 +100,8 @@ class _SlideShowState extends State<SlideShow> {
     restartTimer();
     _controller.animateToPage(
       slide,
-      curve: _kSlideCurve,
-      duration: _kSlideDuration,
+      curve: widget.curve,
+      duration: widget.duration,
     );
     widget.onSlide?.call(slide);
   }


### PR DESCRIPTION
This gives the installer full control over slide animations so that it can perfectly match them with the window title bar. In the screencast below, it looks like the window title bar is part of the slide show but it's in fact a separate widget elsewhere in the widget tree inside a YaruWindowTitleBar. The animations just happen to match thanks to exposing the curve and duration. :)

[Screencast from 2023-01-16 17-54-50.webm](https://user-images.githubusercontent.com/140617/212730927-6cb2bb46-87f4-4ac5-8aed-b73ef8f85103.webm)