### PR TITLE
DropdownBuilder: expose input decoration to allow passing a label etc.

### DIFF
--- a/packages/ubuntu_widgets/lib/src/dropdown_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/dropdown_builder.dart
@@ -30,6 +30,7 @@ class DropdownBuilder<T> extends StatelessWidget {
     required this.values,
     required this.onSelected,
     required this.itemBuilder,
+    this.decoration,
   });
 
   /// The currently selected value or `null` if no value is selected.
@@ -50,6 +51,9 @@ class DropdownBuilder<T> extends StatelessWidget {
   /// Note: The returned widget is set as a child of [DropDownMenuItem].
   final ValueWidgetBuilder<T> itemBuilder;
 
+  /// An optional input decoration for the dropdown.
+  final InputDecoration? decoration;
+
   @override
   Widget build(BuildContext context) {
     return DropdownButtonFormField<T>(
@@ -62,6 +66,7 @@ class DropdownBuilder<T> extends StatelessWidget {
       }).toList(),
       onChanged: onSelected,
       focusColor: Colors.transparent,
+      decoration: decoration,
     );
   }
 }


### PR DESCRIPTION
This allows us to move the "Device for bootloader installation" label as part of the input decoration to free up some more vertical space for the table:

![image](https://user-images.githubusercontent.com/140617/221767966-7b9048ba-ff39-4daa-9731-b38b066f3763.png)