### PR TITLE
CI: pin melos at 2.90

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-      - run: flutter pub global activate melos
+      - run: flutter pub global activate melos 2.9.0
       - run: melos bootstrap
       - run: melos run analyze
 
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-      - run: flutter pub global activate melos
+      - run: flutter pub global activate melos 2.9.0
       - run: melos bootstrap
       - run: melos run format
 
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-      - run: flutter pub global activate melos
+      - run: flutter pub global activate melos 2.9.0
       - run: melos bootstrap
       - run: melos exec --no-private -- \
           flutter pub publish --dry-run

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: sudo apt update
     - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
       env:
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dart-lang/setup-dart@v1
-    - run: dart pub global activate melos
+    - run: dart pub global activate melos 2.9.0
     - run: sudo snap install --classic flutter
     - run: flutter doctor -v
     - run: melos bootstrap

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: melos bootstrap
     - run: melos run generate
     - run: ./.github/scripts/check-outdated-files.sh
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: melos bootstrap
     - run: melos run gen-l10n
     - run: ./.github/scripts/check-outdated-files.sh
@@ -36,7 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: melos bootstrap
     - run: melos run generate
     - run: melos run gen-l10n

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: sudo apt update
     - run: sudo apt install -y lcov
       env:
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: melos bootstrap
     - run: melos run test
 
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-    - run: flutter pub global activate melos
+    - run: flutter pub global activate melos 2.9.0
     - run: sudo apt update
     - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
       env:


### PR DESCRIPTION
Pin for now, we can migrate to 3.x later.
```
Found a melos.yaml file in "/home/runner/work/ubuntu-flutter-plugins/ubuntu-flutter-plugins" but no local installation of Melos.

From version 3.0.0, the melos package must be installed in a pubspec.yaml file next to the melos.yaml file.

For more information on migrating to version 3.0.0, see: https://melos.invertase.dev/guides/migrations#200-to-300

To migrate at a later time, ensure you have version 2.[9](https://github.com/canonical/ubuntu-flutter-plugins/actions/runs/4402115855/jobs/7708945053#step:5:10).0 or below installed: dart pub global activate melos 2.9.0
```
See also:
- https://github.com/canonical/ubuntu-flutter-plugins/actions/runs/4402115855/jobs/7708945053
- https://github.com/canonical/ubuntu-desktop-installer/pull/1584