### PR TITLE
GeoService: add a way to (pre-)initialize local geodata

### DIFF
--- a/packages/timezone_map/lib/src/geodata.dart
+++ b/packages/timezone_map/lib/src/geodata.dart
@@ -86,6 +86,9 @@ class Geodata extends GeoSource {
   }
 
   @override
+  Future<void> init() => _ensureInitialized();
+
+  @override
   Future<Iterable<GeoLocation>> searchLocation(String location) async {
     await _ensureInitialized();
     final key = location.toSearch();

--- a/packages/timezone_map/lib/src/service.dart
+++ b/packages/timezone_map/lib/src/service.dart
@@ -15,6 +15,13 @@ class GeoService {
   /// Removes the specified [source].
   void removeSource(GeoSource source) => _geosources.remove(source);
 
+  /// Initializes the sources.
+  Future<void> init() {
+    return Future.wait([
+      for (final source in _geosources) source.init(),
+    ]);
+  }
+
   /// Looks up the current geographic location.
   Future<GeoLocation?> lookupLocation() async {
     for (final source in _geosources) {

--- a/packages/timezone_map/lib/src/source.dart
+++ b/packages/timezone_map/lib/src/source.dart
@@ -2,6 +2,9 @@ import 'location.dart';
 
 /// Geolocation lookup source.
 abstract class GeoSource {
+  /// Initializes the source.
+  Future<void> init() async {}
+
   /// Looks up the sources and returns current location from the first source
   /// that knows it, if any.
   Future<GeoLocation?> lookupLocation() async => null;

--- a/packages/timezone_map/test/controller_test.mocks.dart
+++ b/packages/timezone_map/test/controller_test.mocks.dart
@@ -46,6 +46,15 @@ class MockGeoService extends _i1.Mock implements _i2.GeoService {
         returnValueForMissingStub: null,
       );
   @override
+  _i4.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
   _i4.Future<_i5.GeoLocation?> lookupLocation() => (super.noSuchMethod(
         Invocation.method(
           #lookupLocation,

--- a/packages/timezone_map/test/service_test.dart
+++ b/packages/timezone_map/test/service_test.dart
@@ -28,6 +28,10 @@ void main() {
     service.addSource(source1);
     service.addSource(source2);
 
+    await service.init();
+    verify(source1.init()).called(1);
+    verify(source2.init()).called(1);
+
     expect(await service.searchLocation('foo'), [copenhagen, gothenburg]);
     verify(source1.searchLocation('foo')).called(1);
     verify(source2.searchLocation('foo')).called(1);

--- a/packages/timezone_map/test/service_test.mocks.dart
+++ b/packages/timezone_map/test/service_test.mocks.dart
@@ -788,6 +788,15 @@ class MockGeoSource extends _i1.Mock implements _i10.GeoSource {
   }
 
   @override
+  _i8.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+  @override
   _i8.Future<_i11.GeoLocation?> lookupLocation() => (super.noSuchMethod(
         Invocation.method(
           #lookupLocation,


### PR DESCRIPTION
It takes a significant amount of time to load and parse the local geodata, which is currently done lazily. While it does not prevent the timezone map from loading, it does cause a ~0.5s delay in the current location being visualized. In the desktop installer, we have plenty of time for pre-initializing such things on startup while we wait for Subiquity's initialization routines.

See also:
- canonical/ubuntu-desktop-installer#1393