### PR TITLE
Optimize loadLocalizedLanguages()

### DIFF
--- a/packages/ubuntu_localizations/lib/src/localizations.dart
+++ b/packages/ubuntu_localizations/lib/src/localizations.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -58,9 +60,9 @@ class LocalizedLanguage {
 /// Builds a sorted list of localized languages.
 ///
 /// [locales] must contain the base locale i.e. the template .arb locale.
-Future<List<LocalizedLanguage>> loadLocalizedLanguages(
+Future<Iterable<LocalizedLanguage>> loadLocalizedLanguages(
     List<Locale> locales) async {
-  final languages = <LocalizedLanguage>[];
+  final languages = SplayTreeMap<String, LocalizedLanguage>();
   for (final locale in locales) {
     final localization = await UbuntuLocalizations.delegate.load(locale);
     if (localization.languageName.isNotEmpty) {
@@ -68,12 +70,11 @@ Future<List<LocalizedLanguage>> loadLocalizedLanguages(
         locale.languageCode,
         locale.countryCode ?? localization.countryCode,
       );
-      languages.add(LocalizedLanguage(localization.languageName, fullLocale));
+      final key = removeDiacritics(localization.languageName);
+      languages[key] = LocalizedLanguage(localization.languageName, fullLocale);
     }
   }
-  languages.sort(
-      (a, b) => removeDiacritics(a.name).compareTo(removeDiacritics(b.name)));
-  return languages;
+  return languages.values;
 }
 
 // A fallback locale that must always exist (same as the template .arb).


### PR DESCRIPTION
The languages are sorted by names with diacritics removed to ensure that e.g. "Íslenska" ("Islenska") appears next to "Italiano" in the list of languages, not somewhere at the end of the list.

Before, the function collected all localized languages into a list, and then sorted the list with a comparator function that removed diacritics from the localized language names on the fly at each comparison call.

Now, the function makes use of an ordered SplayTreeMap using non-diacritic language names as keys and returns a lazy iterable of values in the right order. This ensures that diacritics are only removed once per language name, and the final collection of languages is ordered by the binary tree at insertion time instead of sorting an almost ordered list at the end, which happens to be the worst case for quicksort.