### PR TITLE
ubuntu_widgets: Generalize MenuButtonBuilder

### DIFF
--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -50,16 +50,19 @@ class MenuButtonBuilder<T> extends StatefulWidget {
   /// The `iconBuilder` function is called for each item in the menu.
   /// The returned widgets are set as icons of the menu items.
   ///
-  const MenuButtonBuilder({
+  MenuButtonBuilder({
     super.key,
     this.child,
     this.selected,
-    required this.entries,
+    List<T>? values,
+    List<MenuButtonEntry<T>>? entries,
     this.onSelected,
     this.iconBuilder,
     required this.itemBuilder,
     this.decoration = const InputDecoration(filled: false),
-  });
+  })  : assert((entries != null) != (values != null)),
+        entries =
+            entries ?? values!.map((e) => MenuButtonEntry(value: e)).toList();
 
   /// An optional child widget placed as a label of the button.
   final Widget? child;

--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -4,6 +4,25 @@ import 'package:yaru_icons/yaru_icons.dart';
 
 const _kItemHeight = 40.0;
 
+/// A menu button entry.
+class MenuButtonEntry<T> {
+  /// Creates a menu button entry.
+  const MenuButtonEntry({
+    required this.value,
+    this.enabled = true,
+    this.isDivider = false,
+  });
+
+  /// The value of the entry.
+  final T value;
+
+  /// Whether the entry is enabled.
+  final bool enabled;
+
+  /// Whether the entry is a divider.
+  final bool isDivider;
+}
+
 /// A builder widget that makes it straight-forward to build a menu button
 /// for an arbitrary list of values.
 ///
@@ -35,7 +54,7 @@ class MenuButtonBuilder<T> extends StatefulWidget {
     super.key,
     this.child,
     this.selected,
-    required this.values,
+    required this.entries,
     this.onSelected,
     this.iconBuilder,
     required this.itemBuilder,
@@ -48,10 +67,8 @@ class MenuButtonBuilder<T> extends StatefulWidget {
   /// The currently selected value.
   final T? selected;
 
-  /// The list of values.
-  ///
-  /// For enums, use the enum's `values` constant.
-  final List<T> values;
+  /// The list of entries.
+  final List<MenuButtonEntry<T>> entries;
 
   /// Called when the user selects an item.
   final ValueChanged<T>? onSelected;
@@ -119,7 +136,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
       builder: (context, controller, child) {
         return child!;
       },
-      menuChildren: widget.values.mapIndexed(_buildMenuItem).toList(),
+      menuChildren: widget.entries.mapIndexed(_buildMenuItem).toList(),
       child: Stack(
         children: [
           Positioned.fill(
@@ -180,14 +197,14 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
     );
   }
 
-  Widget _buildMenuItem(int index, T? value) {
-    if (value == null) {
+  Widget _buildMenuItem(int index, MenuButtonEntry<T> item) {
+    if (item.isDivider) {
       return const Divider();
     }
 
     final states = {
       if (widget.selected == null && index == 0) MaterialState.selected,
-      if (widget.selected != null && widget.selected == value)
+      if (widget.selected != null && widget.selected == item.value)
         MaterialState.selected,
       if (widget.onSelected == null) MaterialState.disabled,
     };
@@ -201,17 +218,19 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
 
     return MenuItemButton(
       focusNode: states.contains(MaterialState.selected) ? _focusNode : null,
-      leadingIcon: widget.iconBuilder?.call(context, value, null),
-      onPressed: () {
-        widget.onSelected?.call(value);
-        _controller.close();
-      },
+      leadingIcon: widget.iconBuilder?.call(context, item.value, null),
+      onPressed: item.enabled
+          ? () {
+              widget.onSelected?.call(item.value);
+              _controller.close();
+            }
+          : null,
       style: MenuItemButton.styleFrom(
         minimumSize: minimumSize ?? const Size(0, _kItemHeight),
         maximumSize: maximumSize ?? const Size(double.infinity, _kItemHeight),
         padding: padding ?? _scaledPadding(context),
       ),
-      child: widget.itemBuilder(context, value, null),
+      child: widget.itemBuilder(context, item.value, null),
     );
   }
 }

--- a/packages/ubuntu_widgets/test/menu_button_builder_test.dart
+++ b/packages/ubuntu_widgets/test/menu_button_builder_test.dart
@@ -13,7 +13,8 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            values: TestEnum.values,
+            entries:
+                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
             onSelected: (_) {},
             itemBuilder: (_, value, __) => Text(value.name),
             child: const Text('child'),
@@ -32,7 +33,8 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            values: TestEnum.values,
+            entries:
+                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
             onSelected: (_) {},
             itemBuilder: (_, value, __) => Text(value.name),
           ),
@@ -48,7 +50,8 @@ void main() {
       MaterialApp(
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
-            values: TestEnum.values,
+            entries:
+                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
             onSelected: (_) {},
             iconBuilder: (_, value, __) => const Icon(Icons.arrow_drop_down),
             itemBuilder: (_, value, __) => Text(value.toString()),
@@ -72,7 +75,8 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            values: TestEnum.values,
+            entries:
+                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
             onSelected: (_) {},
             iconBuilder: (_, value, __) => const Icon(Icons.arrow_drop_down),
             itemBuilder: (_, value, __) => Text(value.toString()),
@@ -98,7 +102,8 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            values: TestEnum.values,
+            entries:
+                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
             onSelected: (value) => selectedValue = value,
             iconBuilder: (_, value, __) => const Icon(Icons.arrow_drop_down),
             itemBuilder: (_, value, __) => Text(value.toString()),

--- a/packages/ubuntu_widgets/test/menu_button_builder_test.dart
+++ b/packages/ubuntu_widgets/test/menu_button_builder_test.dart
@@ -13,8 +13,7 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            entries:
-                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
+            values: TestEnum.values,
             onSelected: (_) {},
             itemBuilder: (_, value, __) => Text(value.name),
             child: const Text('child'),
@@ -33,8 +32,7 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            entries:
-                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
+            values: TestEnum.values,
             onSelected: (_) {},
             itemBuilder: (_, value, __) => Text(value.name),
           ),
@@ -50,8 +48,7 @@ void main() {
       MaterialApp(
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
-            entries:
-                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
+            values: TestEnum.values,
             onSelected: (_) {},
             iconBuilder: (_, value, __) => const Icon(Icons.arrow_drop_down),
             itemBuilder: (_, value, __) => Text(value.toString()),
@@ -75,8 +72,7 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            entries:
-                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
+            values: TestEnum.values,
             onSelected: (_) {},
             iconBuilder: (_, value, __) => const Icon(Icons.arrow_drop_down),
             itemBuilder: (_, value, __) => Text(value.toString()),
@@ -102,8 +98,7 @@ void main() {
         home: Material(
           child: MenuButtonBuilder<TestEnum>(
             selected: TestEnum.bar,
-            entries:
-                TestEnum.values.map((e) => MenuButtonEntry(value: e)).toList(),
+            values: TestEnum.values,
             onSelected: (value) => selectedValue = value,
             iconBuilder: (_, value, __) => const Icon(Icons.arrow_drop_down),
             itemBuilder: (_, value, __) => Text(value.toString()),


### PR DESCRIPTION
Makes `MenuButtonBuilder` take a list of `MenuButtonEntry<T>` to allow for more control over the menu entries.