### PR TITLE
CI: drop old 18.04 jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,10 +9,7 @@ on:
 
 jobs:
   bundle:
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,10 +25,7 @@ jobs:
         token: ${{secrets.CODECOV_TOKEN}}
 
   run:
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2


### PR DESCRIPTION
They were added in #44 but now those jobs keep getting stuck. I can't think of a reason why we'd need them here because `handy_window` is not here anymore. :)