### PR TITLE
key_search_test.dart: clean up commented out code that accidentally slipped in

### DIFF
--- a/packages/ubuntu_widgets/test/key_search_test.dart
+++ b/packages/ubuntu_widgets/test/key_search_test.dart
@@ -36,8 +36,6 @@ void main() {
   });
 
   test('key search', () async {
-    //final model = WelcomeModel(MockSubiquityClient());
-    //await model.loadLanguages();
     final languages = [
       'Dansk',
       'Deutsch',


### PR DESCRIPTION
Probably was used in the original test when this was developed in the UDI repo... :)