### PR TITLE
MenuButtonEntry: make selectedEntry nullable

### DIFF
--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -79,8 +79,8 @@ class MenuButtonBuilder<T> extends StatefulWidget {
   final List<MenuButtonEntry<T>> entries;
 
   /// The currently selected entry.
-  MenuButtonEntry<T> get selectedEntry =>
-      entries.firstWhereOrNull((e) => e.value == selected)!;
+  MenuButtonEntry<T>? get selectedEntry =>
+      entries.firstWhereOrNull((e) => e.value == selected);
 
   /// Called when the user selects an item.
   final ValueChanged<T>? onSelected;
@@ -173,7 +173,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
                       child: widget.child != null
                           ? widget.child!
                           : widget.selected != null
-                              ? widget.selectedEntry.child ??
+                              ? widget.selectedEntry?.child ??
                                   widget.itemBuilder(
                                       context, widget.selected as T, null)
                               : const SizedBox.shrink()),


### PR DESCRIPTION
I wrongly assumed the selected value always has a corresponding entry in the list of values/entries.
But this is not the case - e.g. [in the keyboard layout page of the installer ](https://github.com/canonical/ubuntu-desktop-installer/actions/runs/4721572223/jobs/8375003234?pr=1820), where the initially selected index is -1.