### PR TITLE
refactor(ubuntu_test): finder-based localizations

### DIFF
--- a/packages/ubuntu_test/lib/src/common_finders.dart
+++ b/packages/ubuntu_test/lib/src/common_finders.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+
+/// Localization function.
+typedef LocalizationFunction<T> = String Function(T);
+
+/// Ubuntu localization function.
+typedef UbuntuLocalizationFunction = String Function(UbuntuLocalizations);
+
+/// Common finder extensions.
+extension UbuntuCommonFinders on CommonFinders {
+  /// Finds a widget with text translated in [UbuntuLocalizations].
+  Finder ul10n(UbuntuLocalizationFunction tr) => l10n<UbuntuLocalizations>(tr);
+
+  /// Finds a widget with translated text.
+  Finder l10n<T>(
+    LocalizationFunction<T> tr, {
+    bool findRichText = false,
+    bool skipOffstage = true,
+  }) {
+    return byElementPredicate((element) {
+      final l10n = element.lookupLocalizations<T>();
+      return l10n != null &&
+          (find.text(tr(l10n),
+                  findRichText: findRichText,
+                  skipOffstage: skipOffstage) as MatchFinder)
+              .matches(element);
+    });
+  }
+}
+
+extension on Element {
+  T? lookupLocalizations<T>() {
+    Widget? scope;
+    visitAncestorElements((element) {
+      if (element.widget.runtimeType.toString() == '_LocalizationsScope') {
+        scope = element.widget;
+      }
+      return scope == null;
+    });
+    return ((scope as dynamic)?.typeToResources as Map?)?[T];
+  }
+}

--- a/packages/ubuntu_test/lib/src/widget_tester.dart
+++ b/packages/ubuntu_test/lib/src/widget_tester.dart
@@ -1,68 +1,32 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:yaru_test/yaru_test.dart';
 
-final _localizations = <Type, Object>{};
+import 'common_finders.dart';
 
 /// Widget test extensions.
 extension UbuntuWidgetTester on WidgetTester {
-  /// The [UbuntuLocalizations] instance.
-  UbuntuLocalizations get ulang =>
-      localizations<UbuntuLocalizations>(UbuntuLocalizations);
-
-  /// Looks up a localizations instance.
-  T localizations<T>(Type type) {
-    if (_localizations.containsKey(T)) return _localizations[T] as T;
-
-    final result = find.byWidgetPredicate((widget) {
-      final context = element(find.byWidget(widget));
-      return Localizations.of<T>(context, type) != null;
-    });
-
-    if (result.evaluate().isEmpty) {
-      throw StateError('''
-No $T found in the widget tree.
-
-Pump a widget tree with `LocalizationsDelegate<$T>` before calling
-`UbuntuWidgetTester.findLocalizations<$T>()`. For example:
-
-  await tester.pumpWidget(
-    MaterialApp(
-      localizationsDelegates: $T.localizationsDelegates,
-      home: ...
-    ),
-  );
-
-  final l10n = tester.localizations<$T>();
-  expect(find.text(l10n.fooLabel), findsOneWidget);
-''');
-    }
-
-    final l10n = Localizations.of(element(result.first), T)!;
-    _localizations[T] = l10n;
-    if (_localizations.length == 1) addTearDown(_localizations.clear);
-    return l10n;
-  }
-
   /// Taps a _Back_ button.
-  Future<void> tapBack() => tapButton(ulang.backLabel);
+  Future<void> tapBack() => _tapUbuntuButton((l10n) => l10n.backLabel);
 
   /// Taps a _Cancel_ button.
-  Future<void> tapCancel() => tapButton(ulang.cancelLabel);
+  Future<void> tapCancel() => _tapUbuntuButton((l10n) => l10n.cancelLabel);
 
   /// Taps a _Close_ button.
-  Future<void> tapClose() => tapButton(ulang.closeLabel);
+  Future<void> tapClose() => _tapUbuntuButton((l10n) => l10n.closeLabel);
 
   /// Taps a _Continue_ button.
-  Future<void> tapContinue() => tapButton(ulang.continueLabel);
+  Future<void> tapContinue() => _tapUbuntuButton((l10n) => l10n.continueLabel);
 
   /// Taps a _Next_ button.
-  Future<void> tapNext() => tapButton(ulang.nextLabel);
+  Future<void> tapNext() => _tapUbuntuButton((l10n) => l10n.nextLabel);
 
   /// Taps an _Ok_ button.
-  Future<void> tapOk() => tapButton(ulang.okLabel);
+  Future<void> tapOk() => _tapUbuntuButton((l10n) => l10n.okLabel);
 
   /// Taps a _Previous_ button.
-  Future<void> tapPrevious() => tapButton(ulang.previousLabel);
+  Future<void> tapPrevious() => _tapUbuntuButton((l10n) => l10n.previousLabel);
+
+  Future<void> _tapUbuntuButton(UbuntuLocalizationFunction tr) {
+    return tapButton(find.ul10n(tr));
+  }
 }

--- a/packages/ubuntu_test/lib/ubuntu_test.dart
+++ b/packages/ubuntu_test/lib/ubuntu_test.dart
@@ -1,6 +1,7 @@
 /// Provides test extensions for Ubuntu applications.
 library ubuntu_test;
 
+export 'src/common_finders.dart';
 export 'src/file_tester.dart';
 export 'src/integration_tester.dart';
 export 'src/widget_tester.dart';

--- a/packages/ubuntu_test/test/l10n_test.dart
+++ b/packages/ubuntu_test/test/l10n_test.dart
@@ -6,22 +6,34 @@ import 'package:ubuntu_test/ubuntu_test.dart';
 
 void main() async {
   testWidgets('ubuntu localizations', (tester) async {
-    await expectLater(() => tester.ulang.okLabel, throwsStateError);
+    expect(find.ul10n((l10n) => l10n.okLabel), findsNothing);
 
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
-        builder: (context, child) =>
-            Text(UbuntuLocalizations.of(context).okLabel),
+        builder: (context, child) => Column(
+          children: [
+            Text(UbuntuLocalizations.of(context).languageName),
+            Localizations.override(
+              context: context,
+              locale: const Locale('fr'),
+              child: Builder(
+                builder: (context) =>
+                    Text(UbuntuLocalizations.of(context).languageName),
+              ),
+            ),
+          ],
+        ),
       ),
     );
 
-    expect(tester.ulang.okLabel, 'OK');
-    expect(find.text(tester.ulang.okLabel), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('Français'), findsOneWidget);
+    expect(find.ul10n((l10n) => l10n.languageName), findsNWidgets(2));
   });
 
   testWidgets('app localizations', (tester) async {
-    await expectLater(() => tester.al10n.testLabel, throwsStateError);
+    expect(find.l10n<AppLocalizations>((l10n) => l10n.testLabel), findsNothing);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -31,19 +43,21 @@ void main() async {
       ),
     );
 
-    expect(tester.al10n.testLabel, 'test');
-    expect(find.text(tester.al10n.testLabel), findsOneWidget);
+    expect(
+        find.l10n<AppLocalizations>((l10n) => l10n.testLabel), findsOneWidget);
   });
 
   testWidgets('tap buttons', (tester) async {
-    const labels = [
-      'Back',
-      'Cancel',
-      'Close',
-      'Continue',
-      'Next',
-      'OK',
-      'Previous',
+    final ul10n = await UbuntuLocalizations.delegate.load(const Locale('en'));
+
+    final labels = [
+      ul10n.backLabel,
+      ul10n.cancelLabel,
+      ul10n.closeLabel,
+      ul10n.continueLabel,
+      ul10n.nextLabel,
+      ul10n.okLabel,
+      ul10n.previousLabel,
     ];
 
     final actual = <String>[];
@@ -63,25 +77,25 @@ void main() async {
     ));
 
     await tester.tapBack();
-    expect(actual, expected..add(tester.ulang.backLabel));
+    expect(actual, expected..add(ul10n.backLabel));
 
     await tester.tapCancel();
-    expect(actual, expected..add(tester.ulang.cancelLabel));
+    expect(actual, expected..add(ul10n.cancelLabel));
 
     await tester.tapClose();
-    expect(actual, expected..add(tester.ulang.closeLabel));
+    expect(actual, expected..add(ul10n.closeLabel));
 
     await tester.tapContinue();
-    expect(actual, expected..add(tester.ulang.continueLabel));
+    expect(actual, expected..add(ul10n.continueLabel));
 
     await tester.tapNext();
-    expect(actual, expected..add(tester.ulang.nextLabel));
+    expect(actual, expected..add(ul10n.nextLabel));
 
     await tester.tapOk();
-    expect(actual, expected..add(tester.ulang.okLabel));
+    expect(actual, expected..add(ul10n.okLabel));
 
     await tester.tapPrevious();
-    expect(actual, expected..add(tester.ulang.previousLabel));
+    expect(actual, expected..add(ul10n.previousLabel));
   });
 }
 
@@ -115,9 +129,4 @@ class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   @override
   bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) =>
       false;
-}
-
-extension AppLocalizationsTester on WidgetTester {
-  AppLocalizations get al10n =>
-      localizations<AppLocalizations>(AppLocalizations);
 }


### PR DESCRIPTION
Calling `Localizations.of()` leaves behind dependencies on inherited widgets and eventually explodes in more complex tests.