### PR TITLE
test: fix timezone_map test on Flutter 3.10.1+

### DIFF
--- a/packages/timezone_map/test/map_test.dart
+++ b/packages/timezone_map/test/map_test.dart
@@ -191,7 +191,8 @@ class FakeAssetBundle extends CachingAssetBundle {
           {'asset': e, 'dpr': 1.0}
         ])));
     switch (key) {
-      case 'AssetManifest.bin':
+      case 'AssetManifest.bin': // 3.10.0
+      case 'AssetManifest.smcbin': // 3.10.1+
         return const StandardMessageCodec().encodeMessage(fakes)!;
       case 'AssetManifest.json':
         bytes = Uint8List.fromList(jsonEncode(fakes).codeUnits);


### PR DESCRIPTION
AssetManifest.bin was renamed to AssetManifest.smcbin