### PR TITLE
chore(melos): add `melos pub <arg(s)>` command

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -51,6 +51,9 @@ scripts:
     melos exec -c 1 --fail-fast --dir-exists=integration_test -- \
       flutter test integration_test
 
+  # runs "flutter pub <arg(s)>" in all packages
+  pub: melos exec -c 1 -- flutter pub "$@"
+
   # run tests in all packages
   test: >
     melos exec -c 1 --fail-fast --dir-exists=test -- \


### PR DESCRIPTION
Handy for running for example `flutter pub upgrade` for all packages.

See also:
- https://github.com/canonical/ubuntu-desktop-installer/pull/1346