### PR TITLE
feat(ubuntu-logger): make the name optional, default to executable

### DIFF
--- a/packages/ubuntu_logger/lib/src/ubuntu_logger.dart
+++ b/packages/ubuntu_logger/lib/src/ubuntu_logger.dart
@@ -40,7 +40,11 @@ RotatingFileAppender? _fileLog;
 /// A logger that prints to the console and writes to a log file.
 class Logger {
   /// Creates a named logger.
-  Logger(String name) : _logger = log.Logger(name);
+  ///
+  /// If no [name] is specified, the name of the executable is used.
+  Logger([String? name]) : _logger = log.Logger(name ?? _defaultName);
+
+  static final _defaultName = p.basename(Platform.resolvedExecutable);
 
   final log.Logger _logger;
 


### PR DESCRIPTION
There's a common pattern in UDI that the "top-level" logger for exceptions etc. is named after the executable because it doesn't have any specific context. This PR makes it convenient to create such a logger so that we don't need to repeat or share the logic somewhere in UDI.