### PR TITLE
fix(timezone_map): adapt to dio changes

### DIFF
--- a/packages/timezone_map/lib/src/geoip.dart
+++ b/packages/timezone_map/lib/src/geoip.dart
@@ -45,7 +45,7 @@ class GeoIP extends GeoSource {
     try {
       final response = await _sendRequest();
       return _handleResponse(response);
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       if (!CancelToken.isCancel(e)) {
         throw GeoException(e.message ?? '', e);
       }

--- a/packages/timezone_map/lib/src/geoname.dart
+++ b/packages/timezone_map/lib/src/geoname.dart
@@ -55,7 +55,7 @@ class Geoname extends GeoSource {
     try {
       final response = await _sendRequest(location);
       return _handleResponse(response);
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       if (!CancelToken.isCancel(e) && e.error is! SocketException) {
         throw GeoException(e.message ?? '', e);
       }

--- a/packages/timezone_map/pubspec.yaml
+++ b/packages/timezone_map/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.16.0
-  dio: ^5.0.3
+  dio: ^5.2.0
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.4


### PR DESCRIPTION
```
Analyzing timezone_map...                                       

   info • 'DioError' is deprecated and shouldn't be used. Use DioException instead. This will be removed in 6.0.0 • lib/src/geoip.dart:48:10 • deprecated_member_use
   info • 'DioError' is deprecated and shouldn't be used. Use DioException instead. This will be removed in 6.0.0 • lib/src/geoname.dart:58:10 • deprecated_member_use

2 issues found. (ran in 0.9s)
```