### PR TITLE
chore(timezone_map): remove uses-material-design

### DIFF
--- a/packages/timezone_map/pubspec.yaml
+++ b/packages/timezone_map/pubspec.yaml
@@ -30,7 +30,6 @@ dev_dependencies:
   vector_graphics_compiler: ^1.1.4
 
 flutter:
-  uses-material-design: true
   assets:
     - assets/
     - assets/medium/


### PR DESCRIPTION
Fixes the following warning when using timezone_map as a dependency of another package:
```
package:timezone_map has `uses-material-design: true` set but the primary pubspec
contains `uses-material-design: false`. If the application needs material icons,
then `uses-material-design` must be set to true.
```