### PR TITLE
fix: adapt MenuButtonBuilder to padding & font changes in Flutter 3.10

### DIFF
--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -141,6 +141,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
       crossAxisUnconstrained: false,
       style: MenuStyle(
         minimumSize: MaterialStatePropertyAll(Size(_width ?? 0, 0)),
+        visualDensity: const VisualDensity(horizontal: 0, vertical: 0),
       ),
       builder: (context, controller, child) {
         return child!;
@@ -239,6 +240,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
         minimumSize: minimumSize ?? const Size(0, _kItemHeight),
         maximumSize: maximumSize ?? const Size(double.infinity, _kItemHeight),
         padding: padding ?? _scaledPadding(context),
+        textStyle: Theme.of(context).textTheme.labelLarge,
       ),
       child: item.child ?? widget.itemBuilder(context, item.value, null),
     );


### PR DESCRIPTION
# Before

[Screencast from 2023-06-30 14-10-46.webm](https://github.com/canonical/ubuntu-flutter-plugins/assets/140617/737ce78a-75cd-4965-ac07-400028ee409f)

# After

[Screencast from 2023-06-30 14-10-23.webm](https://github.com/canonical/ubuntu-flutter-plugins/assets/140617/50ed52cb-a095-4eb1-afe2-b5a2694b8959)

Fixes: canonical/ubuntu-desktop-installer#2070