### PR TITLE
revert: "ci(release): set up ubuntu_test (#275)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,5 @@
 {
   "packages/ubuntu_localizations": "0.3.3",
   "packages/ubuntu_logger": "0.0.3",
-  "packages/ubuntu_test": "0.1.0-beta.5",
   "packages/ubuntu_widgets": "0.1.2"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,10 +28,6 @@
     "packages/ubuntu_logger": {
       "monorepo-tags": true
     },
-    "packages/ubuntu_test": {
-      "monorepo-tags": true,
-      "prerelease": true
-    },
     "packages/ubuntu_widgets": {
       "monorepo-tags": true
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,8 +30,7 @@
     },
     "packages/ubuntu_test": {
       "monorepo-tags": true,
-      "prerelease": true,
-      "release-as": "0.1.0-beta.6"
+      "prerelease": true
     },
     "packages/ubuntu_widgets": {
       "monorepo-tags": true


### PR DESCRIPTION
There are too many issues with pre-release versions:
- https://github.com/canonical/ubuntu-flutter-plugins/pull/276
- collects bogus changelog entries from older beta releases
- next version of 0.1.0-beta.5 is determined as 0.2.0-beta.5
- when the next version is forced as 0.1.0-beta.6, it sets the pubspec version to 0.1.0-beta.6+-beta.5

Keep releasing it by hand until we are able to release v0.1.0.