### PR TITLE
fix: increase push button height to 40px

### DIFF
--- a/packages/ubuntu_widgets/lib/src/push_button.dart
+++ b/packages/ubuntu_widgets/lib/src/push_button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// The minimum size of a push button.
-const kPushButtonSize = Size(136, 36);
+const kPushButtonSize = Size(136, 40);
 
 /// A classic push button for desktop.
 abstract class PushButton extends ButtonStyleButton {


### PR DESCRIPTION
A temporary measure to sync button, dropdown, and textfield heights.

| Before | After |
|---|---|
| ![Screenshot from 2023-08-01 09-05-59](https://github.com/canonical/ubuntu-flutter-plugins/assets/140617/19e2c65e-b564-48d7-92e3-52925b19ff3d) | ![Screenshot from 2023-08-01 09-05-41](https://github.com/canonical/ubuntu-flutter-plugins/assets/140617/ac1e4271-2b07-4e73-a98f-dd016cbe1612) |

See also:
- https://github.com/ubuntu/yaru.dart/issues/369