### PR TITLE
chore: relax yaru_icons version constraint

### DIFF
--- a/packages/ubuntu_widgets/pubspec.yaml
+++ b/packages/ubuntu_widgets/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   password_strength: ^0.2.0
   ubuntu_localizations: ^0.3.0
   yaru: ^0.9.0
-  yaru_icons: ^1.0.3
+  yaru_icons: ">1.0.0 <3.0.0"
   yaru_widgets: ^2.5.0
 
 dev_dependencies:


### PR DESCRIPTION
yaru_icons 2 changed the API of animated icons but ubuntu_widgets do not use animated icons so either major version is fine.