### PR TITLE
feat(ubuntu_widgets): use fixed padding for MenuButtonBuilder

### DIFF
--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -247,12 +247,9 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
       if (widget.onSelected == null) MaterialState.disabled,
     };
 
-    final direction = Directionality.of(context);
-
     final button = OutlinedButtonTheme.of(context).style;
     final minimumSize = button?.minimumSize?.resolve(states);
     final maximumSize = button?.maximumSize?.resolve(states);
-    final padding = button?.padding?.resolve(states)?.resolve(direction);
 
     return MenuItemButton(
       focusNode: states.contains(MaterialState.selected) ? _focusNode : null,
@@ -268,7 +265,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
             minimumSize: minimumSize ?? const Size(0, _kItemHeight),
             maximumSize:
                 maximumSize ?? const Size(double.infinity, _kItemHeight),
-            padding: padding ?? _scaledPadding(context),
+            padding: _scaledPadding(context),
             textStyle: Theme.of(context).textTheme.labelLarge,
           ),
       child: item.child ?? widget.itemBuilder(context, item.value, null),


### PR DESCRIPTION
Uses a fixed padding for the dropdown menu entries instead of inheriting it from the button theme.
Related issue: https://github.com/ubuntu/app-center/issues/1473 (Yaru uses `EdgeInsets.all(16)` as a button padding now).

@CarlosNihelton please let me know if you think there's a better way of resolving this :)