### PR TITLE
chore: Use package imports

### DIFF
--- a/packages/safe_change_notifier/lib/src/change_notifier.dart
+++ b/packages/safe_change_notifier/lib/src/change_notifier.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 
-import 'notifier_mixin.dart';
+import 'package:safe_change_notifier/src/notifier_mixin.dart';
 
 /// A safe drop-in replacement for Flutter's `ChangeNotifier` that makes
 /// `notifyListeners()` a no-op, rather than an error, after its disposal.

--- a/packages/safe_change_notifier/lib/src/value_notifier.dart
+++ b/packages/safe_change_notifier/lib/src/value_notifier.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 
-import 'notifier_mixin.dart';
+import 'package:safe_change_notifier/src/notifier_mixin.dart';
 
 /// A safe drop-in replacement for Flutter's `ValueNotifier` that makes
 /// `notifyListeners()` a no-op, rather than an error, after its disposal.

--- a/packages/timezone_map/lib/src/controller.dart
+++ b/packages/timezone_map/lib/src/controller.dart
@@ -1,7 +1,7 @@
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 
-import 'location.dart';
-import 'service.dart';
+import 'package:timezone_map/src/location.dart';
+import 'package:timezone_map/src/service.dart';
 
 /// Controls a timezone map widget.
 class TimezoneController extends SafeChangeNotifier {

--- a/packages/timezone_map/lib/src/geodata.dart
+++ b/packages/timezone_map/lib/src/geodata.dart
@@ -4,10 +4,9 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:rbush/rbush.dart';
+import 'package:timezone_map/src/location.dart';
+import 'package:timezone_map/src/source.dart';
 import 'package:xml/xml.dart';
-
-import 'location.dart';
-import 'source.dart';
 
 export 'package:latlong2/latlong.dart' show LatLng;
 

--- a/packages/timezone_map/lib/src/geoip.dart
+++ b/packages/timezone_map/lib/src/geoip.dart
@@ -1,11 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:meta/meta.dart';
+import 'package:timezone_map/src/exception.dart';
+import 'package:timezone_map/src/geodata.dart';
+import 'package:timezone_map/src/location.dart';
+import 'package:timezone_map/src/source.dart';
 import 'package:xml/xml.dart';
-
-import 'exception.dart';
-import 'geodata.dart';
-import 'location.dart';
-import 'source.dart';
 
 final _options = BaseOptions(
   connectTimeout: const Duration(seconds: 5),

--- a/packages/timezone_map/lib/src/geoname.dart
+++ b/packages/timezone_map/lib/src/geoname.dart
@@ -5,10 +5,10 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:meta/meta.dart';
 
-import 'exception.dart';
-import 'geodata.dart';
-import 'location.dart';
-import 'source.dart';
+import 'package:timezone_map/src/exception.dart';
+import 'package:timezone_map/src/geodata.dart';
+import 'package:timezone_map/src/location.dart';
+import 'package:timezone_map/src/source.dart';
 
 final _options = BaseOptions(
   connectTimeout: const Duration(seconds: 2),

--- a/packages/timezone_map/lib/src/map.dart
+++ b/packages/timezone_map/lib/src/map.dart
@@ -5,9 +5,8 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:path/path.dart' as p;
+import 'package:timezone_map/src/latlng.dart';
 import 'package:vector_graphics/vector_graphics.dart';
-
-import 'latlng.dart';
 
 /// The size of the timezone map.
 enum TimezoneMapSize {

--- a/packages/timezone_map/lib/src/service.dart
+++ b/packages/timezone_map/lib/src/service.dart
@@ -1,5 +1,5 @@
-import 'location.dart';
-import 'source.dart';
+import 'package:timezone_map/src/location.dart';
+import 'package:timezone_map/src/source.dart';
 
 /// Provides geolocation lookups.
 class GeoService {

--- a/packages/timezone_map/lib/src/source.dart
+++ b/packages/timezone_map/lib/src/source.dart
@@ -1,4 +1,4 @@
-import 'location.dart';
+import 'package:timezone_map/src/location.dart';
 
 /// Geolocation lookup source.
 abstract class GeoSource {

--- a/packages/ubuntu_flavor/lib/src/ubuntu_flavor.dart
+++ b/packages/ubuntu_flavor/lib/src/ubuntu_flavor.dart
@@ -1,7 +1,8 @@
 import 'package:meta/meta.dart';
 import 'package:platform_linux/platform.dart';
 
-import 'ubuntu_flavor_stub.dart' if (dart.library.io) 'ubuntu_flavor_io.dart';
+import 'package:ubuntu_flavor/src/ubuntu_flavor_stub.dart'
+    if (dart.library.io) 'ubuntu_flavor_io.dart';
 
 @immutable
 class UbuntuFlavor {

--- a/packages/ubuntu_flavor/lib/src/ubuntu_flavor_io.dart
+++ b/packages/ubuntu_flavor/lib/src/ubuntu_flavor_io.dart
@@ -1,6 +1,6 @@
 import 'package:platform_linux/platform.dart';
 
-import 'ubuntu_flavor.dart';
+import 'package:ubuntu_flavor/src/ubuntu_flavor.dart';
 
 UbuntuFlavor? detectUbuntuFlavor([Platform platform = const LocalPlatform()]) {
   if (platform.isBudgie) {

--- a/packages/ubuntu_flavor/lib/src/ubuntu_flavor_stub.dart
+++ b/packages/ubuntu_flavor/lib/src/ubuntu_flavor_stub.dart
@@ -1,6 +1,6 @@
 import 'package:platform_linux/platform.dart';
 
-import 'ubuntu_flavor.dart';
+import 'package:ubuntu_flavor/src/ubuntu_flavor.dart';
 
 UbuntuFlavor? detectUbuntuFlavor([Platform platform = const LocalPlatform()]) =>
     null;

--- a/packages/ubuntu_lints/lib/analysis_options.yaml
+++ b/packages/ubuntu_lints/lib/analysis_options.yaml
@@ -15,6 +15,7 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_required_named_parameters_first
+    - always_use_package_imports
     - avoid_catches_without_on_clauses
     - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_multiple_declarations_per_line
@@ -40,7 +41,6 @@ linter:
     - prefer_final_in_for_each
     - prefer_final_locals
     - prefer_null_aware_method_calls
-    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_void_to_null
     - sized_box_shrink_expand

--- a/packages/ubuntu_localizations/lib/src/data_size.dart
+++ b/packages/ubuntu_localizations/lib/src/data_size.dart
@@ -31,7 +31,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 
-import 'localizations.dart';
+import 'package:ubuntu_localizations/src/localizations.dart';
 
 /// Localized data size formatting.
 extension UbuntuDataSizeLocalizations on UbuntuLocalizations {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations.dart
@@ -8,17 +8,17 @@ import 'package:intl/date_symbols.dart';
 import 'package:intl/date_time_patterns.dart' as intl;
 import 'package:intl/intl.dart';
 
-import 'flutter_localizations_bo.dart';
-import 'flutter_localizations_cy.dart';
-import 'flutter_localizations_dz.dart';
-import 'flutter_localizations_eo.dart';
-import 'flutter_localizations_ga.dart';
-import 'flutter_localizations_ku.dart';
-import 'flutter_localizations_nn.dart';
-import 'flutter_localizations_oc.dart';
-import 'flutter_localizations_se.dart';
-import 'flutter_localizations_tg.dart';
-import 'flutter_localizations_ug.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_bo.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_cy.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_dz.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_eo.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_ga.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_ku.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_nn.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_oc.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_se.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_tg.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations_ug.dart';
 
 abstract class FlutterMaterialLocalizations {
   static const List<LocalizationsDelegate<dynamic>> delegates =

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_bo.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_bo.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateBo<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_cy.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_cy.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateCy<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_dz.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_dz.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateDz<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_eo.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_eo.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateEo<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_ga.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_ga.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateGa<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_ku.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_ku.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateKu<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_nn.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_nn.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateNn<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_oc.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_oc.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateOc<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_se.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_se.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateSe<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_tg.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_tg.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateTg<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_ug.dart
+++ b/packages/ubuntu_localizations/lib/src/flutter/flutter_localizations_ug.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/date_symbols.dart';
 
-import 'flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
 
 class FlutterLocalizationsDelegateUg<T>
     extends FlutterLocalizationsDelegate<T> {

--- a/packages/ubuntu_localizations/lib/src/localizations.dart
+++ b/packages/ubuntu_localizations/lib/src/localizations.dart
@@ -6,8 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/intl_standalone.dart';
 
-import 'flutter/flutter_localizations.dart';
-import 'l10n/ubuntu_localizations.dart';
+import 'package:ubuntu_localizations/src/flutter/flutter_localizations.dart';
+import 'package:ubuntu_localizations/src/l10n/ubuntu_localizations.dart';
 
 export 'l10n/ubuntu_localizations.dart';
 

--- a/packages/ubuntu_test/lib/src/widget_tester.dart
+++ b/packages/ubuntu_test/lib/src/widget_tester.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_test/src/common_finders.dart';
 import 'package:yaru_test/yaru_test.dart';
-
-import 'common_finders.dart';
 
 /// Widget test extensions.
 extension UbuntuWidgetTester on WidgetTester {

--- a/packages/ubuntu_widgets/lib/src/icons.dart
+++ b/packages/ubuntu_widgets/lib/src/icons.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_widgets/src/validated_form_field.dart';
 import 'package:yaru/yaru.dart';
-
-import 'validated_form_field.dart';
 
 /// Presents successful form validation state.
 ///

--- a/packages/ubuntu_widgets/lib/src/list_widget.dart
+++ b/packages/ubuntu_widgets/lib/src/list_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
-
-import '../ubuntu_widgets.dart';
 
 // assumes dense list tiles
 const _kTileHeight = kMinInteractiveDimension;

--- a/packages/ubuntu_widgets/lib/src/validated_form_field.dart
+++ b/packages/ubuntu_widgets/lib/src/validated_form_field.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:form_field_validator/form_field_validator.dart';
 
-import '../ubuntu_widgets.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 
 // The spacing between the form field and the success icon.
 const _kIconSpacing = 10.0;

--- a/packages/wizard_router/lib/src/result.dart
+++ b/packages/wizard_router/lib/src/result.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/widgets.dart';
 
-import 'settings.dart';
+import 'package:wizard_router/src/settings.dart';
 
 class WizardRouteResult<T extends Object?> extends WizardRouteSettings<T> {
   WizardRouteResult(

--- a/packages/wizard_router/lib/src/scope.dart
+++ b/packages/wizard_router/lib/src/scope.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 
-import 'route.dart';
-import 'wizard.dart';
+import 'package:wizard_router/src/route.dart';
+import 'package:wizard_router/src/wizard.dart';
 
 /// The scope of a wizard page.
 ///

--- a/packages/wizard_router/lib/src/wizard.dart
+++ b/packages/wizard_router/lib/src/wizard.dart
@@ -5,10 +5,10 @@ import 'package:flow_builder/flow_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 
-import 'exception.dart';
-import 'route.dart';
-import 'scope.dart';
-import 'settings.dart';
+import 'package:wizard_router/src/exception.dart';
+import 'package:wizard_router/src/route.dart';
+import 'package:wizard_router/src/scope.dart';
+import 'package:wizard_router/src/settings.dart';
 
 part 'controller.dart';
 

--- a/packages/xdg_icons/lib/src/icon.dart
+++ b/packages/xdg_icons/lib/src/icon.dart
@@ -6,9 +6,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:path/path.dart' as path;
 
-import 'data.dart';
-import 'platform_interface.dart';
-import 'theme.dart';
+import 'package:xdg_icons/src/data.dart';
+import 'package:xdg_icons/src/platform_interface.dart';
+import 'package:xdg_icons/src/theme.dart';
 
 class XdgIcon extends StatefulWidget {
   const XdgIcon({

--- a/packages/xdg_icons/lib/src/method_channel.dart
+++ b/packages/xdg_icons/lib/src/method_channel.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-import 'data.dart';
-import 'platform_interface.dart';
+import 'package:xdg_icons/src/data.dart';
+import 'package:xdg_icons/src/platform_interface.dart';
 
 /// An implementation of [XdgIconsPlatform] that uses platform channels.
 class XdgIconsMethodChannel extends XdgIconsPlatform {

--- a/packages/xdg_icons/lib/src/platform_interface.dart
+++ b/packages/xdg_icons/lib/src/platform_interface.dart
@@ -1,7 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-import 'data.dart';
-import 'method_channel.dart';
+import 'package:xdg_icons/src/data.dart';
+import 'package:xdg_icons/src/method_channel.dart';
 
 abstract class XdgIconsPlatform extends PlatformInterface {
   /// Constructs a XdgIconsPlatform.


### PR DESCRIPTION
Use package imports everywhere instead of relative imports, to make it easier to move around files.
https://github.com/canonical/ubuntu-desktop-provision/pull/266/files#r1422349321