### PR TITLE
fix: The MenuButtonBuilder should scale depending on his childrens

### DIFF
--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -185,6 +185,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
               }
             },
             child: Row(
+              mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 DefaultTextStyle(


### PR DESCRIPTION
In this PR:

- The MenuButtonBuilder shouldn't take the full width and should scale depending on the children that it possesses

fix ubuntu/app-center#1530