### PR TITLE
fix: Remove Flexible from AnimatedExpanded

### DIFF
--- a/packages/ubuntu_widgets/lib/src/animated_expanded.dart
+++ b/packages/ubuntu_widgets/lib/src/animated_expanded.dart
@@ -34,22 +34,19 @@ class _AnimatedExpandedState extends State<AnimatedExpanded>
     with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
-    return Flexible(
-      flex: widget.expanded ? 1 : 0,
-      child: AnimatedSize(
+    return AnimatedSize(
+      curve: widget.curve,
+      duration: widget.duration,
+      child: AnimatedOpacity(
         curve: widget.curve,
         duration: widget.duration,
-        child: AnimatedOpacity(
-          curve: widget.curve,
-          duration: widget.duration,
-          opacity: widget.expanded ? 1 : 0,
-          child: Container(
-            constraints: BoxConstraints(
-              maxWidth: widget.expanded ? double.infinity : 0,
-              maxHeight: widget.expanded ? double.infinity : 0,
-            ),
-            child: widget.child,
+        opacity: widget.expanded ? 1 : 0,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: widget.expanded ? double.infinity : 0,
+            maxHeight: widget.expanded ? double.infinity : 0,
           ),
+          child: widget.child,
         ),
       ),
     );


### PR DESCRIPTION
Since the `BoxConstraints` already manages the animated size, I think it is better that the user handles the flex value of the widget and we keep it without flex as default. This makes it easier to use it code with unconstrained size, like in a scrollable context for example.

Another minor refactor is also included here which moves from `Container` to `ConstrainedBox`.