### PR TITLE
feat(ubuntu_flavor)!: use enum instead of immutable class

### DIFF
--- a/packages/ubuntu_flavor/lib/src/ubuntu_flavor.dart
+++ b/packages/ubuntu_flavor/lib/src/ubuntu_flavor.dart
@@ -1,100 +1,33 @@
 import 'package:meta/meta.dart';
 import 'package:platform_linux/platform.dart';
-
 import 'package:ubuntu_flavor/src/ubuntu_flavor_stub.dart'
     if (dart.library.io) 'ubuntu_flavor_io.dart';
 
-@immutable
-class UbuntuFlavor {
-  const UbuntuFlavor({
-    required this.id,
-    required this.name,
-  });
+enum UbuntuFlavor {
+  budgie('Ubuntu Budgie'),
+  cinnamon('Ubuntu Cinnamon'),
+  edubuntu('Edubuntu'),
+  kubuntu('Kubuntu'),
+  kylin('Ubuntu Kylin'),
+  lubuntu('Lubuntu'),
+  mate('Ubuntu MATE'),
+  studio('Ubuntu Studio'),
+  ubuntu('Ubuntu'),
+  unity('Ubuntu Unity'),
+  xubuntu('Xubuntu'),
+  unknown('Unknown');
 
-  static const budgie = UbuntuFlavor(
-    id: 'ubuntu-budgie',
-    name: 'Ubuntu Budgie',
-  );
-
-  static const cinnamon = UbuntuFlavor(
-    id: 'ubuntucinnamon',
-    name: 'Ubuntu Cinnamon',
-  );
-
-  static const edubuntu = UbuntuFlavor(
-    id: 'edubuntu',
-    name: 'Edubuntu',
-  );
-
-  static const kubuntu = UbuntuFlavor(
-    id: 'kubuntu',
-    name: 'Kubuntu',
-  );
-
-  static const kylin = UbuntuFlavor(
-    id: 'ubuntukylin',
-    name: 'Ubuntu Kylin',
-  );
-
-  static const lubuntu = UbuntuFlavor(
-    id: 'lubuntu',
-    name: 'Lubuntu',
-  );
-
-  static const mate = UbuntuFlavor(
-    id: 'ubuntu-mate',
-    name: 'Ubuntu MATE',
-  );
-
-  static const studio = UbuntuFlavor(
-    id: 'ubuntustudio',
-    name: 'Ubuntu Studio',
-  );
-
-  static const ubuntu = UbuntuFlavor(
-    id: 'ubuntu',
-    name: 'Ubuntu',
-  );
-
-  static const unity = UbuntuFlavor(
-    id: 'ubuntu-unity',
-    name: 'Ubuntu Unity',
-  );
-
-  static const xubuntu = UbuntuFlavor(
-    id: 'xubuntu',
-    name: 'Xubuntu',
-  );
-
-  static UbuntuFlavor? detect([
+  const UbuntuFlavor(this.displayName);
+  factory UbuntuFlavor.detect([
     @visibleForTesting Platform platform = const LocalPlatform(),
   ]) {
     return detectUbuntuFlavor(platform);
   }
 
-  final String id;
-  final String name;
+  factory UbuntuFlavor.fromName(String name) => values.firstWhere(
+        (flavor) => flavor.name == name,
+        orElse: () => unknown,
+      );
 
-  UbuntuFlavor copyWith({
-    String? id,
-    String? name,
-  }) {
-    return UbuntuFlavor(
-      id: id ?? this.id,
-      name: name ?? this.name,
-    );
-  }
-
-  @override
-  String toString() => 'UbuntuFlavor(id: $id, name: $name)';
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is UbuntuFlavor && other.id == id && other.name == name;
-  }
-
-  @override
-  int get hashCode => Object.hash(id, name);
+  final String displayName;
 }

--- a/packages/ubuntu_flavor/lib/src/ubuntu_flavor_io.dart
+++ b/packages/ubuntu_flavor/lib/src/ubuntu_flavor_io.dart
@@ -1,8 +1,7 @@
 import 'package:platform_linux/platform.dart';
-
 import 'package:ubuntu_flavor/src/ubuntu_flavor.dart';
 
-UbuntuFlavor? detectUbuntuFlavor([Platform platform = const LocalPlatform()]) {
+UbuntuFlavor detectUbuntuFlavor([Platform platform = const LocalPlatform()]) {
   if (platform.isBudgie) {
     return UbuntuFlavor.budgie;
   }
@@ -32,5 +31,5 @@ UbuntuFlavor? detectUbuntuFlavor([Platform platform = const LocalPlatform()]) {
   if (platform.isXfce) {
     return UbuntuFlavor.xubuntu;
   }
-  return null;
+  return UbuntuFlavor.unknown;
 }

--- a/packages/ubuntu_flavor/lib/src/ubuntu_flavor_stub.dart
+++ b/packages/ubuntu_flavor/lib/src/ubuntu_flavor_stub.dart
@@ -1,6 +1,5 @@
 import 'package:platform_linux/platform.dart';
-
 import 'package:ubuntu_flavor/src/ubuntu_flavor.dart';
 
-UbuntuFlavor? detectUbuntuFlavor([Platform platform = const LocalPlatform()]) =>
-    null;
+UbuntuFlavor detectUbuntuFlavor([Platform platform = const LocalPlatform()]) =>
+    UbuntuFlavor.unknown;

--- a/packages/ubuntu_flavor/test/ubuntu_flavor_test.dart
+++ b/packages/ubuntu_flavor/test/ubuntu_flavor_test.dart
@@ -3,27 +3,9 @@ import 'package:test/test.dart';
 import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 
 void main() {
-  test('data', () {
-    const flavor1 = UbuntuFlavor(id: 'id1', name: 'Name 1');
-    expect(flavor1.id, 'id1');
-    expect(flavor1.name, 'Name 1');
-    expect(flavor1.copyWith(), flavor1);
-    expect(flavor1.hashCode, flavor1.copyWith().hashCode);
-    expect(flavor1.toString(), 'UbuntuFlavor(id: id1, name: Name 1)');
-
-    const flavor2 = UbuntuFlavor(id: 'id2', name: 'Name 2');
-    expect(flavor2.id, 'id2');
-    expect(flavor2.name, 'Name 2');
-    expect(flavor2, isNot(flavor1));
-
-    final copy1 = flavor1.copyWith(id: 'id1.1');
-    expect(copy1.id, 'id1.1');
-    expect(copy1.name, 'Name 1');
-    expect(copy1, isNot(flavor1));
-  });
-
   test('none', () {
-    expect(UbuntuFlavor.detect(FakePlatform(environment: {})), isNull);
+    expect(UbuntuFlavor.detect(FakePlatform(environment: {})),
+        UbuntuFlavor.unknown);
   });
 
   test('original', () {
@@ -126,7 +108,12 @@ void main() {
       UbuntuFlavor.detect(FakePlatform(environment: {
         'XDG_CURRENT_DESKTOP': 'foo:bar',
       })),
-      isNull,
+      UbuntuFlavor.unknown,
     );
+  });
+
+  test('from name', () {
+    expect(UbuntuFlavor.fromName('cinnamon'), UbuntuFlavor.cinnamon);
+    expect(UbuntuFlavor.fromName('foobar'), UbuntuFlavor.unknown);
   });
 }


### PR DESCRIPTION
This simplifies the `ubuntu_flavor` package but introduces a few breaking changes:
* `id` has been replaced by the enum's `name` getter and most of those have changed
* the `name` property has been renamed to `displayName`
* `detect()` returns `UbuntuFlavor.unknown` instead of `null` if flavor can't be detected 
