### PR TITLE
fix: MenuButtonBuilder only find render object when mounted

### DIFF
--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -141,7 +141,7 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
 
   void _updateSize() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if(!mounted) return;
+      if (!mounted) return;
 
       final size = (context.findRenderObject() as RenderBox?)?.size;
       if (_size != size) {

--- a/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
+++ b/packages/ubuntu_widgets/lib/src/menu_button_builder.dart
@@ -141,6 +141,8 @@ class _MenuButtonBuilderState<T> extends State<MenuButtonBuilder<T>> {
 
   void _updateSize() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if(!mounted) return;
+
       final size = (context.findRenderObject() as RenderBox?)?.size;
       if (_size != size) {
         setState(() => _size = size);


### PR DESCRIPTION
In some cases you'll get the following without this fix applied:
```
This widget has been unmounted, so the State no longer has a context (and should be considered defunct). 
```