### PR TITLE
feat(xdg_icons): replace flutter_svg dependency with jovial_svg

### DIFF
--- a/packages/xdg_icons/lib/src/icon.dart
+++ b/packages/xdg_icons/lib/src/icon.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_svg/flutter_svg.dart';
+import 'package:jovial_svg/jovial_svg.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:xdg_icons/src/data.dart';
@@ -131,15 +132,39 @@ class XdgIconState extends State<XdgIcon> {
     final file = File(_icon?.fileName ?? '');
     final size = _resolveSize();
     if (file.existsSync()) {
-      final builder = _icon!.isScalable ? SvgPicture.file : Image.file;
-      return builder(
+      if (_icon!.isScalable) {
+        return SizedBox(
+          width: size.toDouble(),
+          height: size.toDouble(),
+          child: ScalableImageWidget.fromSISource(
+            si: ScalableImageSource.fromSvgFile(
+              file.path,
+              file.readAsStringSync,
+            ),
+          ),
+        );
+      }
+
+      return Image.file(
         file,
         width: size.toDouble(),
         height: size.toDouble(),
       );
     } else if (_icon?.data != null) {
-      final builder = _icon!.isScalable ? SvgPicture.memory : Image.memory;
-      return builder(
+      if (_icon!.isScalable) {
+        return SizedBox(
+          width: size.toDouble(),
+          height: size.toDouble(),
+          child: ScalableImageWidget.fromSISource(
+            si: ScalableImageSource.fromSvgFile(
+              file.path,
+              () => utf8.decode(_icon!.data!),
+            ),
+          ),
+        );
+      }
+
+      return Image.memory(
         Uint8List.fromList(_icon!.data!),
         width: size.toDouble(),
         height: size.toDouble(),

--- a/packages/xdg_icons/pubspec.yaml
+++ b/packages/xdg_icons/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.18.0
   flutter:
     sdk: flutter
-  flutter_svg: ^2.0.10+1
+  jovial_svg: ^1.1.25
   mocktail: ^1.0.0
   path: ^1.9.0
   plugin_platform_interface: ^2.1.2


### PR DESCRIPTION
This allows using SVG icons that have for example the <style> attribute set. An example of an icon theme using this is KDE's Breeze. flutter_svg doesn't support this and without it Breeze's dark icons would render as black even though they're supposed to be white.

See https://github.com/dnfield/flutter_svg/issues/105 for context.

Fixes #472.

CC @jpnurmi 