### PR TITLE
fix(ubuntu_localizations): use fallback if locale is 'POSIX' or 'und'

### DIFF
--- a/packages/ubuntu_localizations/lib/src/localizations.dart
+++ b/packages/ubuntu_localizations/lib/src/localizations.dart
@@ -37,7 +37,7 @@ Future<void> initDefaultLocale([String? locale]) async {
     systemLocale = 'en';
   }
 
-  Intl.defaultLocale = locale ?? await findSystemLocale();
+  Intl.defaultLocale = locale ?? systemLocale;
 }
 
 /// A localized language and its locale.

--- a/packages/ubuntu_localizations/lib/src/localizations.dart
+++ b/packages/ubuntu_localizations/lib/src/localizations.dart
@@ -30,6 +30,13 @@ class GlobalUbuntuLocalizations {
 /// * [Intl.defaultLocale]
 /// * [Intl.systemLocale]
 Future<void> initDefaultLocale([String? locale]) async {
+  var systemLocale = await findSystemLocale();
+
+  // Fallback to 'en' if the system locale is 'POSIX' or undefined.
+  if (systemLocale == 'POSIX' || systemLocale == 'und') {
+    systemLocale = 'en';
+  }
+
   Intl.defaultLocale = locale ?? await findSystemLocale();
 }
 

--- a/packages/ubuntu_localizations/lib/src/localizations.dart
+++ b/packages/ubuntu_localizations/lib/src/localizations.dart
@@ -30,14 +30,10 @@ class GlobalUbuntuLocalizations {
 /// * [Intl.defaultLocale]
 /// * [Intl.systemLocale]
 Future<void> initDefaultLocale([String? locale]) async {
-  var systemLocale = await findSystemLocale();
-
-  // Fallback to 'en' if the system locale is 'POSIX' or undefined.
-  if (systemLocale == 'POSIX' || systemLocale == 'und') {
-    systemLocale = 'en';
-  }
-
-  Intl.defaultLocale = locale ?? systemLocale;
+  Intl.defaultLocale = locale ??
+      await findSystemLocale()
+          // Fallback to 'en' if the system locale is 'POSIX' or undefined.
+          .then((l) => l == 'POSIX' || l == 'und' ? 'en' : l);
 }
 
 /// A localized language and its locale.


### PR DESCRIPTION
If `Intl.defaultLocale` is initialized with `und` (undefined) or `POSIX` localizing a `DateTime` with `DateFormat` (and possibly other things) will throw an exception. See https://github.com/ubuntu/app-center/issues/1659 for more details.

A simple workaround has been suggested [here](https://github.com/ubuntu/app-center/issues/1884#issuecomment-2605281302).
