### PR TITLE
chore(ubuntu_localizations): bump minimum Flutter version

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -8,7 +8,7 @@ command:
   bootstrap:
     environment:
       sdk: ">=3.0.0 <4.0.0"
-      flutter: ">=3.24.3"
+      flutter: ">=3.27.4"
 
     dependencies:
       collection: ^1.18.0

--- a/packages/safe_change_notifier/pubspec.yaml
+++ b/packages/safe_change_notifier/pubspec.yaml
@@ -9,7 +9,7 @@ version: 0.4.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   flutter:

--- a/packages/timezone_map/pubspec.yaml
+++ b/packages/timezone_map/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.18.0

--- a/packages/ubuntu_localizations/pubspec.yaml
+++ b/packages/ubuntu_localizations/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.5.1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.18.0

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.2.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   flutter:

--- a/packages/ubuntu_widgets/pubspec.yaml
+++ b/packages/ubuntu_widgets/pubspec.yaml
@@ -8,7 +8,7 @@ version: 0.7.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.18.0

--- a/packages/wizard_router/example/pubspec.yaml
+++ b/packages/wizard_router/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   flutter:

--- a/packages/wizard_router/pubspec.yaml
+++ b/packages/wizard_router/pubspec.yaml
@@ -9,7 +9,7 @@ version: 1.4.0
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 dependencies:
   collection: ^1.18.0

--- a/packages/xdg_icons/example/pubspec.yaml
+++ b/packages/xdg_icons/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 platforms:
   linux:

--- a/packages/xdg_icons/pubspec.yaml
+++ b/packages/xdg_icons/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.1.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.24.3"
+  flutter: ">=3.27.4"
 
 platforms:
   linux:


### PR DESCRIPTION
Due to the changes in #462 `ubuntu_localizations` requires at least Flutter 3.27.

Turns out we're tracking the Flutter version constraints for all packages in the `melos.yaml` (i.e. running `melos bootstrap` updates the Flutter version constraints in all packages). This means we need to bump it for all packages.

UDENG-6671
UDENG-6586