### PR TITLE
ci: update CLA check to v2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
-        with:
-          exempted-bots: github-actions,renovate
+        uses: canonical/has-signed-canonical-cla@v2
 
   title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the CLA workflow to the [latest version](https://github.com/canonical/has-signed-canonical-cla). The `exempted-bots` has been removed, as proper github bots (with usernames ending in `[bot]` are automatically excluded from the check. We need to continue explicitly excluding weblate, since their automation is using a normal github account. Also see https://github.com/canonical/has-signed-canonical-cla/pull/77