### PR TITLE
chore: release packages

### DIFF
--- a/packages/ubuntu_localizations/CHANGELOG.md
+++ b/packages/ubuntu_localizations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+ - **CHORE**: Bump Flutter to 3.27.4
+
 ## 0.5.1
 
  - **FIX**(l10n): translations update from Hosted Weblate (#445).

--- a/packages/ubuntu_localizations/pubspec.yaml
+++ b/packages/ubuntu_localizations/pubspec.yaml
@@ -3,7 +3,7 @@ description: Provides extra localizations for Ubuntu applications.
 homepage: https://github.com/canonical/ubuntu-flutter-plugins
 repository: https://github.com/canonical/ubuntu-flutter-plugins/tree/main/packages/ubuntu_localizations
 issue_tracker: https://github.com/canonical/ubuntu-flutter-plugins/issues
-version: 0.5.1
+version: 0.5.2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/packages/ubuntu_test/CHANGELOG.md
+++ b/packages/ubuntu_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+ - **CHORE**: Bump yaru_test and flutter_html
+
 ## 0.2.2
 
  - Bump dependencies

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_html: ^3.0.0-beta.2
+  flutter_html: ^3.0.0
   flutter_markdown: ^0.7.3+1
   flutter_svg: ^2.0.10+1
   flutter_test:

--- a/packages/ubuntu_test/pubspec.yaml
+++ b/packages/ubuntu_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Provides test extensions for Ubuntu applications.
 homepage: https://github.com/canonical/ubuntu-flutter-plugins
 repository: https://github.com/canonical/ubuntu-flutter-plugins/tree/main/packages/ubuntu_test
 issue_tracker: https://github.com/canonical/ubuntu-flutter-plugins/issues
-version: 0.2.2
+version: 0.2.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/ubuntu_widgets/CHANGELOG.md
+++ b/packages/ubuntu_widgets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+ - **CHORE**: Bump yaru version
+
 ## 0.7.1
 
  - **FIX**: MenuButtonBuilder only find render object when mounted (#449).

--- a/packages/ubuntu_widgets/pubspec.yaml
+++ b/packages/ubuntu_widgets/pubspec.yaml
@@ -4,7 +4,7 @@ description: |
 homepage: https://github.com/canonical/ubuntu-flutter-plugins
 repository: https://github.com/canonical/ubuntu-flutter-plugins/tree/main/packages/ubuntu_widgets
 issue_tracker: https://github.com/canonical/ubuntu-flutter-plugins/issues
-version: 0.7.1
+version: 0.7.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Releases new versions of the following packages:
- `ubuntu_localizations` `0.5.2` (migrated to Flutter `>=3.27` with minor changes)
- `ubuntu_test` `0.2.3` (updated `yaru_test` to `^0.3.0`)
- `ubuntu_widgets` `0.7.2` (updated `yaru` to `>=6.0.0 <8.0.0`)

(I'll manually release those after merging the PR and will have a look at the automated release workflows later)

UDENG-6586