### PR TITLE
fix: Preserve trailing commas

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -7,7 +7,7 @@ packages:
 command:
   bootstrap:
     environment:
-      sdk: ^3.3.0
+      sdk: ">=3.0.0 <4.0.0"
       flutter: ">=3.27.4"
 
     dependencies:


### PR DESCRIPTION
> [!NOTE]  
> This can't be merged until Dart SDK is at least ^3.6.0 (possibly 3.8.0)

After the new formatter was introduced it started removing trailing commas. Trailing commas is a feature which most of the Flutter & Dart community like since it makes the git diffs less noisy and the code easier to read.

My suggestion in that we add trailing_commas: preserve to the next version of this package, so that the people depending on this package can continue to enjoy their trailing commas.