### PR TITLE
chore: publish xdg_icons 0.1.1

### DIFF
--- a/packages/xdg_icons/CHANGELOG.md
+++ b/packages/xdg_icons/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## 0.1.1
+
+ - deps: replace flutter_svg with jovial_svg to support SVG styles (#475)
+
 ## 0.1.0
 
 > Note: This release has breaking changes.
@@ -12,8 +18,6 @@
 
  - **REFACTOR**: Apply ubuntu lints to all packages (#340).
  - **FEAT**: Activate ubuntu_lints.
-
-# Changelog
 
 ## [0.0.3](https://github.com/canonical/ubuntu-flutter-plugins/compare/xdg_icons-v0.0.2...xdg_icons-v0.0.3) (2023-10-18)
 

--- a/packages/xdg_icons/pubspec.yaml
+++ b/packages/xdg_icons/pubspec.yaml
@@ -3,7 +3,7 @@ description: XDG theme icons for Flutter.
 homepage: https://github.com/canonical/ubuntu-flutter-plugins
 repository: https://github.com/canonical/ubuntu-flutter-plugins/tree/main/packages/xdg_icons
 issue_tracker: https://github.com/canonical/ubuntu-flutter-plugins/issues
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Release `xdg_icons` `0.1.1` including the changes from #475.