### PR TITLE
feat: allow overriding desktop and distro for tests

### DIFF
--- a/packages/platform_linux/lib/src/linux_desktop.dart
+++ b/packages/platform_linux/lib/src/linux_desktop.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 
 /// Detects the Linux desktop environment.
@@ -43,6 +44,16 @@ extension PlatformLinuxDesktop on Platform {
 
   /// [Xfce](https://xfce.org/)
   bool get isXfce => _isDesktop('xfce');
+
+  /// Overrides the detected desktop environment for testing.
+  ///
+  /// The values must be in lowercase.
+  @visibleForTesting
+  set xdgDesktopOverride(List<String>? names) {
+    final cacheId = identityHashCode(this);
+    _xdgCurrentDesktopCacheId = cacheId;
+    _xdgCurrentDesktopCache = names;
+  }
 
   bool _isDesktop(String name) {
     return _getXdgCurrentDesktop(this)?.contains(name) ?? false;

--- a/packages/platform_linux/lib/src/linux_distro.dart
+++ b/packages/platform_linux/lib/src/linux_distro.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 
 /// Detects the Linux distro.
@@ -33,6 +34,14 @@ extension PlatformLinuxDistro on Platform {
 
   /// [Ubuntu](https://ubuntu.com/)
   bool get isUbuntu => _isDistro('ubuntu');
+
+  /// Overrides the detected distro for testing.
+  @visibleForTesting
+  set distroOverride(String? id) {
+    final cacheId = identityHashCode(this);
+    _osReleaseCacheId = cacheId;
+    _osReleaseCache = {'ID': id};
+  }
 
   bool _isDistro(String id) {
     final os = _getOsRelease(this);

--- a/packages/platform_linux/pubspec.yaml
+++ b/packages/platform_linux/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 
 dependencies:
   platform: ^3.1.0
+  meta: ^1.17.0
 
 dev_dependencies:
   mockito: ^5.4.4

--- a/packages/platform_linux/test/linux_desktop_test.dart
+++ b/packages/platform_linux/test/linux_desktop_test.dart
@@ -133,4 +133,22 @@ void main() {
     );
     expect(platform.isXfce, isTrue);
   });
+
+  test('Override', () {
+    final platform = FakePlatform(
+      environment: {
+        'XDG_CURRENT_DESKTOP': 'KDE',
+      },
+    );
+    platform.xdgDesktopOverride = ['budgie', 'gnome'];
+    expect({
+      'kde': platform.isKDE,
+      'budgie': platform.isBudgie,
+      'gnome': platform.isGNOME,
+    }, {
+      'kde': isFalse,
+      'budgie': isTrue,
+      'gnome': isTrue,
+    });
+  });
 }

--- a/packages/platform_linux/test/linux_distro_test.dart
+++ b/packages/platform_linux/test/linux_distro_test.dart
@@ -237,6 +237,35 @@ LOGO=ubuntu-logo
       }).call,
     );
   });
+
+  test('Override', () {
+    IOOverrides.runZoned(
+      () {
+        final platform = FakePlatform();
+        platform.distroOverride = 'opensuse';
+        expect(
+          {'manjaro': platform.isManjaro, 'opensuse': platform.isOpenSUSE},
+          {'manjaro': isFalse, 'opensuse': isTrue},
+        );
+      },
+      createFile: MockTextFiles({
+        '/etc/os-release': MockTextFile('''
+NAME="Manjaro Linux"
+PRETTY_NAME="Manjaro Linux"
+ID=manjaro
+ID_LIKE=arch
+BUILD_ID=rolling
+ANSI_COLOR="32;1;24;144;200"
+HOME_URL="https://manjaro.org/"
+DOCUMENTATION_URL="https://wiki.manjaro.org/"
+SUPPORT_URL="https://forum.manjaro.org/"
+BUG_REPORT_URL="https://docs.manjaro.org/reporting-bugs/"
+PRIVACY_POLICY_URL="https://manjaro.org/privacy-policy/"
+LOGO=manjarolinux
+'''),
+      }).call,
+    );
+  });
 }
 
 class MockTextFiles {


### PR DESCRIPTION
In a test for my app, I wanted to have `platform.isUbuntu` be true. But there wasn't an easy way to set the distro without specifying the entire os-release file.

This PR adds `platform.xdgDesktopOverride` and `platform.distroOverride` so users of the `platform_linux` package can override the distro/desktop.

Before this PR:
```dart
IOOverrides.runZoned(
  () {
    final platform = FakePlatform(
      environment: {
        'XDG_CURRENT_DESKTOP': 'GNOME',
      },
    );
  },
  createFile: MockTextFiles({
    '/etc/os-release': MockTextFile('''
PRETTY_NAME="Ubuntu 23.04"
NAME="Ubuntu"
VERSION_ID="23.04"
VERSION="23.04 (Lunar Lobster)"
VERSION_CODENAME=lunar
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=lunar
LOGO=ubuntu-logo
'''),
  }).call,
);
```
After this PR:
```dart
final platform = FakePlatform();
platform.xdgDesktopOverride = ['gnome'];
platform.distroOverride = 'ubuntu';
```