### PR TITLE
chore(deps): update dependency yaru to v9

### DIFF
--- a/packages/timezone_map/example/pubspec.yaml
+++ b/packages/timezone_map/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   timezone_map: ^0.1.0
-  yaru: ^8.3.0
+  yaru: ^9.0.0
 
 dev_dependencies:
   ubuntu_lints: ^0.4.1+1

--- a/packages/ubuntu_widgets/pubspec.yaml
+++ b/packages/ubuntu_widgets/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   form_field_validator: ^1.1.0
   password_strength: ^0.2.0
   ubuntu_localizations: ^0.5.2+2
-  yaru: ^8.2.0
+  yaru: ^9.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/xdg_icons/example/pubspec.yaml
+++ b/packages/xdg_icons/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   xdg_icons: ^0.1.2
-  yaru: ^8.3.0
+  yaru: ^9.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
https://github.com/canonical/ubuntu-flutter-plugins/pull/500 made the upgrade to `9.0.0` and not `^9.0.0` like it should be.

Closes https://github.com/canonical/ubuntu-flutter-plugins/pull/500

---

UDENG-8704