### PR TITLE
fix(ListWidget)!: fix accessibility focus trap and remove tabFocusNode

### DIFF
--- a/packages/ubuntu_widgets/lib/src/list_widget.dart
+++ b/packages/ubuntu_widgets/lib/src/list_widget.dart
@@ -106,7 +106,6 @@ class _ListWidgetState extends State<ListWidget> {
                 return KeyEventResult.ignored;
               },
               child: KeySearch(
-                autofocus: false,
                 onSearch: widget.onKeySearch ?? (_) => -1,
                 child: LayoutBuilder(
                   builder: (context, constraints) {


### PR DESCRIPTION
Previously, keyboard and screen reader users would get stuck on the internal focusNode. Navigation was restricted to the up and down arrows, which was not obvious to the user, and there was no accessible way to review the currently selected option or easily exit the list.

This change wraps the ListWidget in a FocusScope with a key interceptor to improve navigation:

- Users can now TAB and Shift+TAB out of the list to the next/previous focusable element (e.g., the "Next" button).

- Arrow keys continue to function for internal list navigation.

**BREAKING CHANGE:** The tabFocusNode parameter has been removed as it is no longer required for focus traversal.