### PR TITLE
fix(a11y): resolve focus traps and silent semantics in ListWidget

### DIFF
--- a/packages/ubuntu_widgets/lib/src/list_widget.dart
+++ b/packages/ubuntu_widgets/lib/src/list_widget.dart
@@ -66,15 +66,27 @@ class _ListWidgetState extends State<ListWidget> {
     final box = _scrollableKey.currentContext?.findRenderObject() as RenderBox?;
     if (box?.hasSize != true) return;
 
-    final scrollOffset = _scrollController!.offset;
-    final tileOffset = index * _kTileHeight;
     final viewHeight = box!.size.height;
+    final scrollOffset = _scrollController!.offset;
+    final tileTop = index * _kTileHeight;
+    final tileBottom = tileTop + _kTileHeight;
 
-    // jump and center align the selected item is fully outside the viewport
-    if (tileOffset < scrollOffset - _kTileHeight ||
-        tileOffset > scrollOffset + viewHeight) {
-      final center = tileOffset - viewHeight / 2 + _kTileHeight / 2;
-      _scrollController?.jumpTo(center);
+  // Check if the tile is off-screen (even partially)
+    if (tileTop < scrollOffset || tileBottom > scrollOffset + viewHeight) {
+      final distance = (tileTop - scrollOffset).abs();
+
+      if (distance > viewHeight) {
+        final center = tileTop - viewHeight / 2 + _kTileHeight / 2;
+        _scrollController?.jumpTo(center);
+      }
+      // If it's just above the viewport, align it to the top.
+      else if (tileTop < scrollOffset) {
+        _scrollController?.jumpTo(tileTop);
+      }
+      // If it's just below the viewport, align it to the bottom.
+      else {
+        _scrollController?.jumpTo(tileBottom - viewHeight);
+      }
     }
   }
 

--- a/packages/ubuntu_widgets/lib/src/list_widget.dart
+++ b/packages/ubuntu_widgets/lib/src/list_widget.dart
@@ -41,6 +41,8 @@ class ListWidget extends StatefulWidget {
 class _ListWidgetState extends State<ListWidget> {
   final _scrollableKey = GlobalKey();
   ScrollController? _scrollController;
+  final FocusNode _wrapperNode = FocusNode(debugLabel: 'ListWrapper');
+  final FocusNode _anchorNode = FocusNode(debugLabel: 'ListAnchor');
 
   @override
   void didUpdateWidget(ListWidget oldWidget) {
@@ -53,6 +55,8 @@ class _ListWidgetState extends State<ListWidget> {
   @override
   void dispose() {
     _scrollController?.dispose();
+    _wrapperNode.dispose();
+    _anchorNode.dispose();
     super.dispose();
   }
 
@@ -76,6 +80,9 @@ class _ListWidgetState extends State<ListWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final effectiveSelectedIndex = widget.selectedIndex < 0
+        ? 0
+        : widget.selectedIndex;
     return YaruBorderContainer(
       clipBehavior: Clip.antiAlias,
       // Wrap the list in a FocusScope to define it as a group in order to allow propper focus behaviour
@@ -83,6 +90,15 @@ class _ListWidgetState extends State<ListWidget> {
         child: Builder(
           builder: (context) {
             return Focus(
+              focusNode: _wrapperNode,
+              canRequestFocus: true,
+              onFocusChange: (hasFocus) {
+                if (hasFocus && _wrapperNode.hasPrimaryFocus) {
+                  if (_anchorNode.canRequestFocus) {
+                    _anchorNode.requestFocus();
+                  }
+                }
+              },
               // Intercept Key Events to handle Tab to Exit
               onKeyEvent: (node, event) {
                 if (event is KeyDownEvent &&
@@ -114,12 +130,15 @@ class _ListWidgetState extends State<ListWidget> {
                         constraints.maxHeight <= 0) {
                       return const SizedBox.expand();
                     }
-                    // calculate initial center-alignment
+                    final double rawOffset =
+                        effectiveSelectedIndex * _kTileHeight -
+                        constraints.maxHeight / 2 +
+                        _kTileHeight / 2;
+
                     _scrollController ??= ScrollController(
-                      initialScrollOffset: widget.selectedIndex * _kTileHeight -
-                          constraints.maxHeight / 2 +
-                          _kTileHeight / 2,
+                      initialScrollOffset: rawOffset < 0 ? 0.0 : rawOffset,
                     );
+
                     return FocusTraversalGroup(
                       policy: OrderedTraversalPolicy(),
                       child: ListView.builder(
@@ -128,18 +147,56 @@ class _ListWidgetState extends State<ListWidget> {
                         shrinkWrap: widget.shrinkWrap,
                         itemExtent: _kTileHeight,
                         itemCount: widget.itemCount,
-                        itemBuilder: (context, index) => Builder(
-                          builder: (context) {
-                            if (index == widget.selectedIndex) {
-                              // bring a half-visible selected item into the viewport
-                              context.findRenderObject()?.showOnScreen();
-                            }
-                            return FocusTraversalOrder(
-                              order: NumericFocusOrder(index.toDouble()),
-                              child: widget.itemBuilder(context, index),
+                        itemBuilder: (context, index) {
+                          Widget item = widget.itemBuilder(context, index);
+
+                          if (index == widget.selectedIndex) {
+                            item = Builder(
+                              builder: (ctx) {
+                                ctx.findRenderObject()?.showOnScreen();
+                                return widget.itemBuilder(context, index);
+                              },
                             );
-                          },
-                        ),
+                          }
+
+                          final isEffectiveAnchor =
+                              index == effectiveSelectedIndex;
+
+                          item = Focus(
+                            focusNode: isEffectiveAnchor ? _anchorNode : null,
+                            canRequestFocus: isEffectiveAnchor,
+                            skipTraversal: true,
+                            onFocusChange: isEffectiveAnchor
+                                ? (hasFocus) {
+                                    if (hasFocus &&
+                                        _anchorNode.hasPrimaryFocus) {
+                                      _anchorNode.nextFocus();
+                                    }
+                                  }
+                                : null,
+                            onKeyEvent: (node, event) {
+                              if (event is KeyDownEvent) {
+                                if (index == widget.itemCount - 1 &&
+                                    event.logicalKey ==
+                                        LogicalKeyboardKey.arrowDown) {
+                                  return KeyEventResult.handled;
+                                }
+                                if (index == 0 &&
+                                    event.logicalKey ==
+                                        LogicalKeyboardKey.arrowUp) {
+                                  return KeyEventResult.handled;
+                                }
+                              }
+                              return KeyEventResult.ignored;
+                            },
+                            child: item,
+                          );
+
+                          return FocusTraversalOrder(
+                            order: NumericFocusOrder(index.toDouble()),
+                            child: item,
+                          );
+                        },
                       ),
                     );
                   },

--- a/packages/ubuntu_widgets/lib/src/list_widget.dart
+++ b/packages/ubuntu_widgets/lib/src/list_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru/widgets.dart';
 
+// assumes dense list tiles
 const _kTileHeight = kMinInteractiveDimension;
 
 /// A list view that scrolls to the selected item and offers a callback for key
@@ -48,6 +49,15 @@ class _ListWidgetState extends State<ListWidget> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.selectedIndex != widget.selectedIndex) {
       _scrollTo(widget.selectedIndex);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _anchorNode.canRequestFocus) {
+          if (_anchorNode.children.isNotEmpty) {
+            _anchorNode.children.first.requestFocus();
+          } else {
+            _anchorNode.requestFocus();
+          }
+        }
+      });
     }
   }
 
@@ -91,6 +101,7 @@ class _ListWidgetState extends State<ListWidget> {
 
     return YaruBorderContainer(
       clipBehavior: Clip.antiAlias,
+      // Wrap the list in a FocusScope to define it as a group in order to allow propper focus behaviour
       child: FocusScope(
         child: Builder(
           builder: (context) {
@@ -100,15 +111,24 @@ class _ListWidgetState extends State<ListWidget> {
               onFocusChange: (hasFocus) {
                 if (hasFocus && _wrapperNode.hasPrimaryFocus) {
                   if (_anchorNode.canRequestFocus) {
-                    _anchorNode.requestFocus();
+                    if (_anchorNode.children.isNotEmpty) {
+                      _anchorNode.children.first.requestFocus();
+                    } else {
+                      _anchorNode.requestFocus();
+                    }
                   }
                 }
               },
+              // Intercept Key Events to handle Tab to Exit
               onKeyEvent: (node, event) {
                 if (event is KeyDownEvent &&
                     event.logicalKey == LogicalKeyboardKey.tab) {
+                  // Get the current scope (the list)
                   final scope = FocusScope.of(context);
 
+                  // Move focus in the PARENT scope (The Page).
+                  // This jumps from the List to the Next or previous element
+                  // completely skipping the internal list items.
                   if (HardwareKeyboard.instance.isShiftPressed) {
                     scope.enclosingScope?.previousFocus();
                   } else {
@@ -118,6 +138,7 @@ class _ListWidgetState extends State<ListWidget> {
                   return KeyEventResult.handled;
                 }
 
+                // Let Arrow keys pass through to the ListView naturally
                 return KeyEventResult.ignored;
               },
               child: KeySearch(
@@ -130,6 +151,7 @@ class _ListWidgetState extends State<ListWidget> {
                       return const SizedBox.expand();
                     }
 
+                    // calculate initial center-alignment
                     final rawOffset = effectiveSelectedIndex * _kTileHeight -
                         constraints.maxHeight / 2 +
                         _kTileHeight / 2;

--- a/packages/ubuntu_widgets/lib/src/list_widget.dart
+++ b/packages/ubuntu_widgets/lib/src/list_widget.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru/widgets.dart';
 
-// assumes dense list tiles
 const _kTileHeight = kMinInteractiveDimension;
 
 /// A list view that scrolls to the selected item and offers a callback for key
@@ -71,20 +70,15 @@ class _ListWidgetState extends State<ListWidget> {
     final tileTop = index * _kTileHeight;
     final tileBottom = tileTop + _kTileHeight;
 
-  // Check if the tile is off-screen (even partially)
     if (tileTop < scrollOffset || tileBottom > scrollOffset + viewHeight) {
       final distance = (tileTop - scrollOffset).abs();
 
       if (distance > viewHeight) {
         final center = tileTop - viewHeight / 2 + _kTileHeight / 2;
         _scrollController?.jumpTo(center);
-      }
-      // If it's just above the viewport, align it to the top.
-      else if (tileTop < scrollOffset) {
+      } else if (tileTop < scrollOffset) {
         _scrollController?.jumpTo(tileTop);
-      }
-      // If it's just below the viewport, align it to the bottom.
-      else {
+      } else {
         _scrollController?.jumpTo(tileBottom - viewHeight);
       }
     }
@@ -92,12 +86,11 @@ class _ListWidgetState extends State<ListWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final effectiveSelectedIndex = widget.selectedIndex < 0
-        ? 0
-        : widget.selectedIndex;
+    final effectiveSelectedIndex =
+        widget.selectedIndex < 0 ? 0 : widget.selectedIndex;
+
     return YaruBorderContainer(
       clipBehavior: Clip.antiAlias,
-      // Wrap the list in a FocusScope to define it as a group in order to allow propper focus behaviour
       child: FocusScope(
         child: Builder(
           builder: (context) {
@@ -111,16 +104,11 @@ class _ListWidgetState extends State<ListWidget> {
                   }
                 }
               },
-              // Intercept Key Events to handle Tab to Exit
               onKeyEvent: (node, event) {
                 if (event is KeyDownEvent &&
                     event.logicalKey == LogicalKeyboardKey.tab) {
-                  // Get the current scope (the list)
                   final scope = FocusScope.of(context);
 
-                  // Move focus in the PARENT scope (The Page).
-                  // This jumps from the List to the Nex  or previous element
-                  // completely skipping the internal list items.
                   if (HardwareKeyboard.instance.isShiftPressed) {
                     scope.enclosingScope?.previousFocus();
                   } else {
@@ -130,7 +118,6 @@ class _ListWidgetState extends State<ListWidget> {
                   return KeyEventResult.handled;
                 }
 
-                // Let Arrow keys pass through to the ListView naturally
                 return KeyEventResult.ignored;
               },
               child: KeySearch(
@@ -142,8 +129,8 @@ class _ListWidgetState extends State<ListWidget> {
                         constraints.maxHeight <= 0) {
                       return const SizedBox.expand();
                     }
-                    final double rawOffset =
-                        effectiveSelectedIndex * _kTileHeight -
+
+                    final rawOffset = effectiveSelectedIndex * _kTileHeight -
                         constraints.maxHeight / 2 +
                         _kTileHeight / 2;
 
@@ -160,16 +147,7 @@ class _ListWidgetState extends State<ListWidget> {
                         itemExtent: _kTileHeight,
                         itemCount: widget.itemCount,
                         itemBuilder: (context, index) {
-                          Widget item = widget.itemBuilder(context, index);
-
-                          if (index == widget.selectedIndex) {
-                            item = Builder(
-                              builder: (ctx) {
-                                ctx.findRenderObject()?.showOnScreen();
-                                return widget.itemBuilder(context, index);
-                              },
-                            );
-                          }
+                          var item = widget.itemBuilder(context, index);
 
                           final isEffectiveAnchor =
                               index == effectiveSelectedIndex;
@@ -204,8 +182,13 @@ class _ListWidgetState extends State<ListWidget> {
                             child: item,
                           );
 
-                          return FocusTraversalOrder(
+                          item = FocusTraversalOrder(
                             order: NumericFocusOrder(index.toDouble()),
+                            child: item,
+                          );
+
+                          return Semantics(
+                            selected: index == widget.selectedIndex,
                             child: item,
                           );
                         },


### PR DESCRIPTION
- Implemented a focus wrapper and anchor node system to safely escort Tab traversal directly to list items, bypassing silent Scrollable background viewports.
- Clamped initial scroll offset calculations to prevent out-of-bounds focus rejections on initial load when selectedIndex is -1.
- Added boundary constraints (walls) to the item-level KeyEvent interceptors to prevent arrow-key navigation from dropping focus into the background container at the edges of the list.
- Preserved original Tab-to-exit scope traversal.