### PR TITLE
feat: add COSMIC desktop environment

### DIFF
--- a/packages/platform_linux/example/desktop.dart
+++ b/packages/platform_linux/example/desktop.dart
@@ -7,6 +7,7 @@ void main() {
 
   print('Budgie: ${platform.isBudgie}');
   print('Cinnamon: ${platform.isCinnamon}');
+  print('COSMIC: ${platform.isCOSMIC}');
   print('Deepin: ${platform.isDeepin}');
   print('Enlightenment: ${platform.isEnlightenment}');
   print('GNOME: ${platform.isGNOME}');

--- a/packages/platform_linux/lib/src/linux_desktop.dart
+++ b/packages/platform_linux/lib/src/linux_desktop.dart
@@ -14,6 +14,9 @@ extension PlatformLinuxDesktop on Platform {
   /// [Cinnamon](https://github.com/linuxmint/Cinnamon)
   bool get isCinnamon => _isDesktop('x-cinnamon');
 
+  /// [COSMIC](https://system76.com/cosmic)
+  bool get isCOSMIC => _isDesktop('cosmic');
+
   /// [Deepin](https://www.deepin.org/en/)
   bool get isDeepin => _isDesktop('deepin');
 

--- a/packages/platform_linux/test/linux_desktop_test.dart
+++ b/packages/platform_linux/test/linux_desktop_test.dart
@@ -6,6 +6,7 @@ void main() {
     final platform = FakePlatform(environment: {});
     expect(platform.isBudgie, isFalse);
     expect(platform.isCinnamon, isFalse);
+    expect(platform.isCOSMIC, isFalse);
     expect(platform.isDeepin, isFalse);
     expect(platform.isEnlightenment, isFalse);
     expect(platform.isGNOME, isFalse);
@@ -35,6 +36,15 @@ void main() {
       },
     );
     expect(platform.isCinnamon, isTrue);
+  });
+
+  test('COSMIC', () {
+    final platform = FakePlatform(
+      environment: {
+        'XDG_CURRENT_DESKTOP': 'COSMIC',
+      },
+    );
+    expect(platform.isCOSMIC, isTrue);
   });
 
   test('Deepin', () {


### PR DESCRIPTION
Closes https://github.com/canonical/ubuntu-flutter-plugins/issues/469. 
Verified working on my install of the Fedora COSMIC spin.

If possible, please can you also review https://github.com/canonical/ubuntu-flutter-plugins/pull/501